### PR TITLE
performAction returns a try so exceptions can be logged

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowAction.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowAction.scala
@@ -2,6 +2,8 @@ package com.coxautodata.waimak.dataflow
 
 import java.util.UUID
 
+import scala.util.Try
+
 /**
   * An action to be performed as part of a data flow. Actions declare what input labels they expect in order to start
   * execution (0 .. N) and can produce outputs associated with the output labels (0 .. N). Executors will use these labels
@@ -48,7 +50,7 @@ trait DataFlowAction[T, C] {
     * @param flowContext context of the flow in which this action runs
     * @return the action outputs (these must be declared in the same order as their labels in [[outputLabels]])
     */
-  def performAction(inputs: DataFlowEntities[T], flowContext: C): ActionResult[T]
+  def performAction(inputs: DataFlowEntities[T], flowContext: C): Try[ActionResult[T]]
 
   /**
     * Action has the responsibility of assessing itself and produce DataFlowActionState, that will be used by the

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowException.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowException.scala
@@ -1,3 +1,3 @@
 package com.coxautodata.waimak.dataflow
 
-class DataFlowException(val text: String) extends RuntimeException(text)
+class DataFlowException(val text: String, val cause: Throwable = null) extends RuntimeException(text, cause)

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowExecutor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowExecutor.scala
@@ -1,5 +1,7 @@
 package com.coxautodata.waimak.dataflow
 
+import scala.util.{Failure, Success}
+
 /**
   * Created by Alexei Perelighin on 11/01/18.
   */
@@ -18,5 +20,23 @@ trait DataFlowExecutor[T, C] {
     * Used to report events on the flow.
     */
   def flowReporter: FlowReporter[T, C]
+
+  /**
+    * Execute the action by calling it's performAction function and unpack the result.
+    *
+    * @param action        Action to be performed
+    * @param inputEntities Inputs for the actions
+    * @param flowContext   Context of the dataflow
+    * @return
+    */
+  def executeAction(action: DataFlowAction[T, C], inputEntities: DataFlowEntities[T], flowContext: C): Seq[Option[T]] = {
+    flowReporter.reportActionStarted(action, flowContext)
+    action.performAction(inputEntities, flowContext) match {
+      case Success(v) =>
+        flowReporter.reportActionFinished(action, flowContext)
+        v
+      case Failure(e) => throw new DataFlowException(s"Exception performing action: ${action.logLabel}", e)
+    }
+  }
 
 }

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/InterceptorAction.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/InterceptorAction.scala
@@ -2,6 +2,8 @@ package com.coxautodata.waimak.dataflow
 
 import java.util.UUID
 
+import scala.util.Try
+
 /**
   * This action can be added to the flow over an existing action, it will be scheduled instead of it and can override or
   * intercept the behaviour of an action.
@@ -42,7 +44,7 @@ class InterceptorAction[T, C](val intercepted: DataFlowAction[T, C]) extends Dat
     * @param flowContext context of the flow in which this action runs
     * @return the action outputs (these must be declared in the same order as their labels in [[outputLabels]])
     */
-  final override def performAction(inputs: DataFlowEntities[T], flowContext: C): ActionResult[T] = {
+  final override def performAction(inputs: DataFlowEntities[T], flowContext: C): Try[ActionResult[T]] = {
     val res = instead(inputs, flowContext)
     res
   }
@@ -59,7 +61,7 @@ class InterceptorAction[T, C](val intercepted: DataFlowAction[T, C]) extends Dat
     * @param flowContext
     * @return
     */
-  def instead(inputs: DataFlowEntities[T], flowContext: C): ActionResult[T] = intercepted.performAction(inputs, flowContext)
+  def instead(inputs: DataFlowEntities[T], flowContext: C): Try[ActionResult[T]] = intercepted.performAction(inputs, flowContext)
 
   /**
     * Calls the intercepted.flowState.

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/PostActionInterceptor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/PostActionInterceptor.scala
@@ -2,21 +2,25 @@ package com.coxautodata.waimak.dataflow
 
 import com.coxautodata.waimak.log.Logging
 
+import scala.util.Try
+
 case class PostActionInterceptor[T, C](toIntercept: DataFlowAction[T, C]
                                        , postActions: Seq[PostAction[T, C]])
   extends InterceptorAction[T, C](toIntercept) with Logging {
 
-  override def instead(inputs: DataFlowEntities[T], flowContext: C): ActionResult[T] = {
-    val res = intercepted.performAction(inputs, flowContext).toArray
-    postActions.groupBy(_.labelToIntercept).foreach{
-      v =>
-        val label = v._1
-        val actionsForLabel = v._2
-        val pos = intercepted.outputLabels.indexOf(label)
-        if (pos < 0) throw new DataFlowException(s"Can not apply post action to label $label, it does not exist in action ${intercepted.logLabel}.")
-        res(pos) = actionsForLabel.foldLeft(res(pos))((z, a) => a.run(z, flowContext))
+  override def instead(inputs: DataFlowEntities[T], flowContext: C): Try[ActionResult[T]] = {
+    val tryRes = intercepted.performAction(inputs, flowContext).map(_.toArray)
+    tryRes.foreach { res =>
+      postActions.groupBy(_.labelToIntercept).foreach {
+        v =>
+          val label = v._1
+          val actionsForLabel = v._2
+          val pos = intercepted.outputLabels.indexOf(label)
+          if (pos < 0) throw new DataFlowException(s"Can not apply post action to label $label, it does not exist in action ${intercepted.logLabel}.")
+          res(pos) = actionsForLabel.foldLeft(res(pos))((z, a) => a.run(z, flowContext))
+      }
     }
-    res.toList
+    tryRes.map(_.toList)
   }
 
   def addPostAction(newAction: PostAction[T, C]): PostActionInterceptor[T, C] = newAction match {

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/SequentialDataFlowExecutor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/SequentialDataFlowExecutor.scala
@@ -3,6 +3,7 @@ package com.coxautodata.waimak.dataflow
 import com.coxautodata.waimak.log.Logging
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success}
 
 /**
   * Created by Alexei Perelighin 2017/12/27
@@ -37,7 +38,10 @@ class SequentialDataFlowExecutor[T, C](override val flowReporter: FlowReporter[T
       logInfo(s"Submitting action ${action.logLabel}")
       //TODO: left for compatibility, need to change the data flow entities to know about optional
       flowReporter.reportActionStarted(action, dataFlow.flowContext)
-      val actionOutputs: Seq[Option[T]] = action.performAction(inputEntities, dataFlow.flowContext)
+      val actionOutputs: Seq[Option[T]] = action.performAction(inputEntities, dataFlow.flowContext) match {
+        case Success(v) => v
+        case Failure(e) => throw new DataFlowException(s"Exception performing action: ${action.logLabel}", e)
+      }
       flowReporter.reportActionFinished(action, dataFlow.flowContext)
       df.executed(action, actionOutputs)
     }

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/SequentialDataFlowExecutor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/SequentialDataFlowExecutor.scala
@@ -3,7 +3,6 @@ package com.coxautodata.waimak.dataflow
 import com.coxautodata.waimak.log.Logging
 
 import scala.annotation.tailrec
-import scala.util.{Failure, Success}
 
 /**
   * Created by Alexei Perelighin 2017/12/27
@@ -37,12 +36,7 @@ class SequentialDataFlowExecutor[T, C](override val flowReporter: FlowReporter[T
 
       logInfo(s"Submitting action ${action.logLabel}")
       //TODO: left for compatibility, need to change the data flow entities to know about optional
-      flowReporter.reportActionStarted(action, dataFlow.flowContext)
-      val actionOutputs: Seq[Option[T]] = action.performAction(inputEntities, dataFlow.flowContext) match {
-        case Success(v) => v
-        case Failure(e) => throw new DataFlowException(s"Exception performing action: ${action.logLabel}", e)
-      }
-      flowReporter.reportActionFinished(action, dataFlow.flowContext)
+      val actionOutputs: Seq[Option[T]] = executeAction(action, inputEntities, dataFlow.flowContext)
       df.executed(action, actionOutputs)
     }
     (wave, resFlow)

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SimpleAction.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SimpleAction.scala
@@ -3,6 +3,8 @@ package com.coxautodata.waimak.dataflow.spark
 import com.coxautodata.waimak.dataflow._
 import org.apache.spark.sql._
 
+import scala.util.Try
+
 
 /**
   * Instances of this class build a bridge between OOP part of the Waimak engine and functional definition of the
@@ -26,9 +28,9 @@ class SimpleAction[T, C](val inputLabels: List[String], val outputLabels: List[S
     * @param inputs the DataFlowEntities corresponding to the inputLabels
     * @return the action outputs (these must be declared in the same order as their labels in outputLabels)
     */
-  override def performAction(inputs: DataFlowEntities[T], flowContext: C): ActionResult[T] = {
+  override def performAction(inputs: DataFlowEntities[T], flowContext: C): Try[ActionResult[T]] = {
     val params: Map[String, T] = inputs.filterLabels(inputLabels).entities
-    exec(params)
+    Try(exec(params))
   }
 
 }

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkDataFlow.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkDataFlow.scala
@@ -8,6 +8,8 @@ import com.coxautodata.waimak.metastore.HadoopDBConnector
 import org.apache.hadoop.fs.{FileAlreadyExistsException, Path, PathOperationException}
 import org.apache.spark.sql.{Dataset, SparkSession}
 
+import scala.util.Try
+
 /**
   * Introduces spark session into the data flows
   */
@@ -73,7 +75,7 @@ private[spark] case class CommitAction(commitLabels: Map[String, LabelCommitDefi
 
   override val requiresAllInputs = false
 
-  override def performAction(inputs: DataFlowEntities[Dataset[_]], flowContext: SparkFlowContext): ActionResult[Dataset[_]] = {
+  override def performAction(inputs: DataFlowEntities[Dataset[_]], flowContext: SparkFlowContext): Try[ActionResult[Dataset[_]]] = Try {
 
     // Create path objects
     val srcDestMap: Map[String, (Path, Path)] = commitLabels.map {

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestInputAction.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestInputAction.scala
@@ -1,5 +1,7 @@
 package com.coxautodata.waimak.dataflow
 
+import scala.util.Try
+
 /**
   * Created by Alexei Perelighin on 11/01/18.
   */
@@ -7,6 +9,6 @@ class TestInputAction(val inputLabels: List[String], val outputLabels: List[Stri
                       , output: DataFlowEntities[String] => ActionResult[String]
                       , override val requiresAllInputs: Boolean = true) extends DataFlowAction[String, EmptyFlowContext] {
 
-  override def performAction(inputs: DataFlowEntities[String], flowContext: EmptyFlowContext): ActionResult[String] = output(inputs)
+  override def performAction(inputs: DataFlowEntities[String], flowContext: EmptyFlowContext): Try[ActionResult[String]] = Try(output(inputs))
 
 }

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestInterceptorAction.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestInterceptorAction.scala
@@ -2,6 +2,8 @@ package com.coxautodata.waimak.dataflow
 
 import org.scalatest.{FunSpec, Matchers}
 
+import scala.util.Success
+
 /**
   * Created by Alexei Perelighin on 2018/02/27
   */
@@ -40,7 +42,7 @@ class TestInterceptorAction extends FunSpec with Matchers {
       val post = new PostActionInterceptor[String, EmptyFlowContext](action, Seq(TransformPostAction(appendFunc, "o1")))
       val res = post.performAction(emptyInputs, new EmptyFlowContext)
 
-      res should be(Seq(Some("v1_6789"), Some("v2")))
+      res should be(Success(Seq(Some("v1_6789"), Some("v2"))))
     }
 
     it("post second output") {
@@ -48,7 +50,7 @@ class TestInterceptorAction extends FunSpec with Matchers {
       val post = new PostActionInterceptor[String, EmptyFlowContext](action, Seq(TransformPostAction(appendFunc, "o2")))
       val res = post.performAction(emptyInputs, new EmptyFlowContext)
 
-      res should be(Seq(Some("v1"), Some("v2_6789")))
+      res should be(Success(Seq(Some("v1"), Some("v2_6789"))))
     }
 
     it("post None output") {
@@ -56,7 +58,7 @@ class TestInterceptorAction extends FunSpec with Matchers {
       val post = new PostActionInterceptor[String, EmptyFlowContext](action, Seq(TransformPostAction(appendFunc, "o2")))
       val res = post.performAction(emptyInputs, new EmptyFlowContext)
 
-      res should be(Seq(Some("v1"), None))
+      res should be(Success(Seq(Some("v1"), None)))
     }
 
     it("post non existing name") {

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestPresetAction.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestPresetAction.scala
@@ -1,5 +1,7 @@
 package com.coxautodata.waimak.dataflow
 
+import scala.util.Try
+
 /**
   * Created by Alexei Perelighin on 11/01/18.
   */
@@ -7,6 +9,6 @@ class TestPresetAction(val inputLabels: List[String], val outputLabels: List[Str
                        , output: () => ActionResult[String]
                        , override val requiresAllInputs: Boolean = true) extends DataFlowAction[String, EmptyFlowContext] {
 
-  override def performAction(inputs: DataFlowEntities[String], flowContext: EmptyFlowContext): ActionResult[String] = output()
+  override def performAction(inputs: DataFlowEntities[String], flowContext: EmptyFlowContext): Try[ActionResult[String]] = Try(output())
 
 }

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestSimpleDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestSimpleDataFlow.scala
@@ -2,6 +2,8 @@ package com.coxautodata.waimak.dataflow
 
 import org.scalatest.{FunSpec, Matchers}
 
+import scala.util.Try
+
 class TestSimpleDataFlow extends FunSpec with Matchers {
 
   describe("Add actions success") {
@@ -827,6 +829,6 @@ class TestSimpleDataFlow extends FunSpec with Matchers {
 
 class TestEmptyAction(val inputLabels: List[String], val outputLabels: List[String]) extends DataFlowAction[String, EmptyFlowContext] {
 
-  override def performAction(inputs: DataFlowEntities[String], flowContext: EmptyFlowContext): List[Option[String]] = List.empty
+  override def performAction(inputs: DataFlowEntities[String], flowContext: EmptyFlowContext): Try[List[Option[String]]] = Try(List.empty)
 
 }

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
@@ -8,6 +8,8 @@ import org.apache.hadoop.fs.FileAlreadyExistsException
 import org.apache.spark.sql.{AnalysisException, Dataset}
 import org.apache.spark.sql.functions._
 
+import scala.util.Try
+
 /**
   * Created by Alexei Perelighin on 22/12/17.
   */
@@ -363,9 +365,11 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
         .alias("csv_2", "person")
         .stageAndCommitParquet(baseDest, snapshotFolder = Some("generatedTimestamp=2018-03-13-16-19-00"))("person")
 
-      intercept[FileAlreadyExistsException] {
+      val res = intercept[DataFlowException] {
         executor.execute(flow)
       }
+      res.text.split(": ", 3).zipWithIndex.collect{case (s, i) if i != 1 => s}.mkString(" ") should be ("Exception performing action Action: CommitAction Inputs: [csv_2,person] Outputs: []")
+      res.cause shouldBe a[FileAlreadyExistsException]
     }
 
     it("stage csv to parquet and commit then use label afterwards") {
@@ -505,10 +509,11 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
           .alias("csv_2", "person")
           .writeParquet(baseDest)("person", "items")
 
-        val res = intercept[AnalysisException] {
+        val res = intercept[DataFlowException] {
           sequentialExecutor.execute(flow)
         }
-        res.getSimpleMessage should be(s"Path does not exist: file:$baseDest/person_written;")
+        res.cause shouldBe a[AnalysisException]
+        res.cause.asInstanceOf[AnalysisException].getSimpleMessage should be(s"Path does not exist: file:$baseDest/person_written;")
       }
 
       it("tag dependency between write and open") {
@@ -683,13 +688,13 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
 
 class TestEmptySparkAction(val inputLabels: List[String], val outputLabels: List[String]) extends SparkDataFlowAction {
 
-  override def performAction(inputs: DataFlowEntities[Dataset[_]], flowContext: SparkFlowContext): List[Option[Dataset[_]]] = List.empty
+  override def performAction(inputs: DataFlowEntities[Dataset[_]], flowContext: SparkFlowContext): Try[List[Option[Dataset[_]]]] = Try(List.empty)
 
 }
 
 class TestTwoInputsAndOutputsAction(override val inputLabels: List[String], override val outputLabels: List[String], run: (Dataset[_], Dataset[_]) => (Dataset[_], Dataset[_])) extends SparkDataFlowAction {
 
-  override def performAction(inputs: DataFlowEntities[Dataset[_]], flowContext: SparkFlowContext): ActionResult[Dataset[_]] = {
+  override def performAction(inputs: DataFlowEntities[Dataset[_]], flowContext: SparkFlowContext): Try[ActionResult[Dataset[_]]] = Try{
     if (inputLabels.length != 2 && outputLabels.length != 2) throw new IllegalArgumentException("Number of input label and output labels must be 2")
     val res: (Dataset[_], Dataset[_]) = run(inputs.get(inputLabels(0)), inputs.get(inputLabels(1)))
     Seq(Some(res._1), Some(res._2))


### PR DESCRIPTION
# Description

Previously if an action raised an exception when performAction was called, or SimpleAction failed inside the exec no information about the underlying action was logged in the exception making flows difficult to debug. Now the perform action returns a Try, and the scheduler should handle this and raise a DataFlowException with the underlying cause given, with the DataFlowException contain a message along with the logLabel (containing action name and inputs/outputs).

This should make failing actions in the flow easier to identify.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

There is a unit test that checks the exception type, the exception message and exception cause and message.