### PR TITLE
Submit all impala commit queries in a single connection (rather than one per label)

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkActions.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkActions.scala
@@ -22,7 +22,7 @@ object SparkActions {
     * @param sparkDataFlow
     */
   implicit class SparkDataFlowExtension(sparkDataFlow: SparkDataFlow) extends Logging {
-    
+
 
     /**
       * Transforms 1 input DataSet to 1 output DataSet using function f, which is a scala function.
@@ -603,7 +603,8 @@ object SparkActions {
       * You can optionally give a snapshot folder name so resulting committed table looks like:
       * /destBasePath/label/snapshotFolder/
       *
-      * @param connection     Hadoop database connection object
+      * @param connection     Hadoop database connection object. Reuse same object instance for each call of this function
+      *                       to allow reuse of the underlying connection
       * @param destBasePath   Base path
       * @param labels         Labels of the dataframe to stage, resulting in the tablename
       * @param snapshotFolder Optional snapshot name

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/metastore/MetastoreUtils.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/metastore/MetastoreUtils.scala
@@ -110,9 +110,10 @@ trait HadoopDBConnector extends DBConnector {
     * @param tableName        name of the table
     * @param path             path of the table location
     * @param partitionColumns optional list of partition columns
+    * @return the sql statements which need executing to perform the table recreation
     */
-  def recreateTableFromParquet(tableName: String, path: String, partitionColumns: Seq[String] = Seq.empty): Unit = {
-    submitAtomicResultlessQueries(dropTableParquetDDL(tableName) +: createTableFromParquetDDL(tableName, path, partitionColumns = partitionColumns))
+  def recreateTableFromParquetDDLs(tableName: String, path: String, partitionColumns: Seq[String] = Seq.empty): Seq[String] = {
+    dropTableParquetDDL(tableName) +: createTableFromParquetDDL(tableName, path, partitionColumns = partitionColumns)
   }
 
   /**
@@ -125,11 +126,12 @@ trait HadoopDBConnector extends DBConnector {
     * @param tableName        name of the table
     * @param path             path of the table location
     * @param partitionColumns optional list of partition columns
+    * @return the sql statements which need executing to perform the table update
     */
-  def updateTableParquetLocation(tableName: String, path: String, partitionColumns: Seq[String] = Seq.empty): Unit = {
+  def updateTableParquetLocationDDLs(tableName: String, path: String, partitionColumns: Seq[String] = Seq.empty): Seq[String] = {
     {
-      if (partitionColumns.nonEmpty || forceRecreateTables) recreateTableFromParquet(tableName, path, partitionColumns)
-      else submitAtomicResultlessQueries(createTableFromParquetDDL(tableName, path) :+ updateTableLocationDDL(tableName, path))
+      if (partitionColumns.nonEmpty || forceRecreateTables) recreateTableFromParquetDDLs(tableName, path, partitionColumns)
+      else createTableFromParquetDDL(tableName, path) :+ updateTableLocationDDL(tableName, path)
     }
   }
 }

--- a/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
+++ b/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
@@ -76,10 +76,10 @@ case class ImpalaJDBCConnector(sparkSession: SparkSession, jdbcString: String, f
   * @param sparkSession SparkSession object
   */
 case class ImpalaDummyConnector(sparkSession: SparkSession, forceRecreateTables: Boolean = false) extends ImpalaDBConnector {
-  var ranDDLs: List[String] = List.empty
+  var ranDDLs: List[List[String]] = List.empty
 
   override private[metastore] def runQueries(ddls: Seq[String]): Seq[Option[ResultSet]] = {
-    ranDDLs = ranDDLs ++ ddls
+    ranDDLs = ranDDLs :+ ddls.toList
     Seq(None)
   }
 }

--- a/waimak-impala/src/test/scala/com/coxautodata/waimak/metastore/TestImpalaDBConnector.scala
+++ b/waimak-impala/src/test/scala/com/coxautodata/waimak/metastore/TestImpalaDBConnector.scala
@@ -99,20 +99,20 @@ class TestImpalaDBConnector extends SparkAndTmpDirSpec {
       val person_recreateParquet = new File(testingBaseDirName, "dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00").list().filter(_.endsWith(".parquet")).head
 
       connector.ranDDLs should be {
-        List(
+        List(List(
           "drop table if exists items",
           s"create external table if not exists items like parquet 'file:$testingBaseDirName/dest/items/amount=1/$itemsParquet' partitioned by (amount string) stored as parquet location '$testingBaseDirName/dest/items'",
           "alter table items recover partitions",
           s"create external table if not exists person like parquet 'file:$testingBaseDirName/dest/person/generatedTimestamp=2018-03-13-16-19-00/$personParquet' stored as parquet location '$testingBaseDir/dest/person/generatedTimestamp=2018-03-13-16-19-00'",
           s"alter table person set location '$testingBaseDirName/dest/person/generatedTimestamp=2018-03-13-16-19-00'"
-        )
+        ))
       }
 
       connectorRecreate.ranDDLs should be {
-        List(
+        List(List(
           "drop table if exists person_recreate",
           s"create external table if not exists person_recreate like parquet 'file:$testingBaseDirName/dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00/$person_recreateParquet' stored as parquet location '$testingBaseDir/dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00'"
-        )
+        ))
       }
     }
   }


### PR DESCRIPTION
# Description

Previously, for every label being committed to Impala, we opened a new connection. This PR proposes a change so that queries will be submitted using a single connection, which is a lot more efficient.

Fixes #9 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Modified ImpalaDummyConnector slightly so that we can differentiate in tests between queries being submitted all in one go, and separate batches. With this, I have specified in the TestImpalaDBConnector that I wish the queries to be submitted in one go, and the original implementation failed. The new implementation passes.
