### PR TITLE
Feature/better interceptor description

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/PostActionInterceptor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/PostActionInterceptor.scala
@@ -23,6 +23,11 @@ case class PostActionInterceptor[T, C](toIntercept: DataFlowAction[C]
     tryRes.map(_.toList)
   }
 
+  override def description: String =
+       super.description + "\n" +
+      "Intercepted " + toIntercept.description + "\n" +
+      "Intercepted with " + postActions.map(_.description).mkString(" ")
+
   def addPostAction(newAction: PostAction[T, C]): PostActionInterceptor[T, C] = newAction match {
     // Cache already exists, so ignore
     case CachePostAction(_, l) if postActions.exists(a => a.isInstanceOf[CachePostAction[T, C]] && a.labelToIntercept == l) =>
@@ -42,6 +47,10 @@ case class PostActionInterceptor[T, C](toIntercept: DataFlowAction[C]
 
 sealed abstract class PostAction[T, C](val labelToIntercept: String) {
   def run: (Option[T], C) => Option[T]
+
+  def postActionName: String = getClass.getSimpleName
+
+  def description = s"PostAction: $postActionName Label: ${labelToIntercept}"
 }
 
 sealed case class CachePostAction[T, C](run: (Option[T], C) => Option[T], override val labelToIntercept: String) extends PostAction[T, C](labelToIntercept)

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/PostActionInterceptor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/PostActionInterceptor.scala
@@ -26,7 +26,7 @@ case class PostActionInterceptor[T, C](toIntercept: DataFlowAction[C]
   override def description: String =
        super.description + "\n" +
       "Intercepted " + toIntercept.description + "\n" +
-      "Intercepted with " + postActions.map(_.description).mkString(" ")
+      "Intercepted with: " + postActions.map(_.description).mkString(", ")
 
   def addPostAction(newAction: PostAction[T, C]): PostActionInterceptor[T, C] = newAction match {
     // Cache already exists, so ignore

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestInterceptorAction.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestInterceptorAction.scala
@@ -71,6 +71,15 @@ class TestInterceptorAction extends FunSpec with Matchers {
 
       res.text should be(s"Can not apply post action to label doesnotexist, it does not exist in action ${action.guid}: Action: TestPresetAction Inputs: [] Outputs: [o1,o2].")
     }
+
+    it("description test") {
+      val action = new TestPresetAction(List.empty, List("o1", "o2"), func2None)
+      val post = new PostActionInterceptor[String, EmptyFlowContext](action, Seq(TransformPostAction(appendFunc, "o2"), CachePostAction(null, "o1")))
+
+      post.description should be("Action: PostActionInterceptor Inputs: [] Outputs: [o1,o2]"
+        + "\nIntercepted Action: TestPresetAction Inputs: [] Outputs: [o1,o2]"
+        + "\nIntercepted with: PostAction: TransformPostAction Label: o2, PostAction: CachePostAction Label: o1")
+    }
   }
 
 }


### PR DESCRIPTION
# Description

The intercepted action description has been extended. It now looks something like the following, for an intercepted action with a transform and cache intercept:

Action: PostActionInterceptor Inputs: [example_in] Outputs: [example_out]
Intercepted Action: TestAction Inputs: [example_in] Outputs: [example_out]
Intercepted with: TransformPostAction on [example_out], CachePostAction on [example_out]

Fixes # (issue)

Information about the underlying intercepted is no longer lost.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A unit test has been added.
