### PR TITLE
Hotfix 1.4.2: Issue using ADLS for Waimak tmp directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.coxautodata</groupId>
     <artifactId>waimak-parent_2.11</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.1</version>
+    <version>1.4.2-SNAPSHOT</version>
 
     <name>Waimak</name>
     <description>An open-source tool that helps data teams row their own boats. Copyright 2018 Cox Automotive UK

--- a/waimak-azure-table/pom.xml
+++ b/waimak-azure-table/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-configuration/pom.xml
+++ b/waimak-configuration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-core/pom.xml
+++ b/waimak-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala
@@ -1,5 +1,6 @@
 package com.coxautodata.waimak.dataflow.spark
 
+import java.net.URI
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.SparkSession
 
@@ -11,7 +12,10 @@ import org.apache.spark.sql.SparkSession
   * @param spark the SparkSession
   */
 case class SparkFlowContext(spark: SparkSession) {
-  //TODO: explore initialisation with non Hadoop files systems
-  lazy val fileSystem: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+
+  private val uriToUse = spark.conf.get("spark.waimak.fs.defaultFS", spark.sparkContext.hadoopConfiguration.get("fs.defaultFS"))
+
+  lazy val fileSystem: FileSystem = FileSystem.get(new URI(uriToUse), spark.sparkContext.hadoopConfiguration)
+
 }
 

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.coxautodata.waimak.dataflow.{ActionResult, _}
 import org.apache.commons.io.FileUtils
-import org.apache.hadoop.fs.{FileAlreadyExistsException, Path}
+import org.apache.hadoop.fs.{FileAlreadyExistsException, FileSystem, Path}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{AnalysisException, Dataset, SparkSession}
 
@@ -701,8 +701,9 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
       val emptyFlow = Waimak.sparkFlow(spark, new Path("file://" + testingBaseDir.toAbsolutePath.toString + "/tmp").toString)
       emptyFlow.prepareForExecution()
 
-      emptyFlow.flowContext.fileSystem.getUri.toString should be ("file:///")
-
+      // Test the flow filesystem differs from what the default one would be
+      emptyFlow.flowContext.fileSystem.getUri.toString should be("file:///")
+      FileSystem.get(spark.sparkContext.hadoopConfiguration).getUri.toString should be("hdfs://localhost")
     }
   }
 

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
@@ -4,9 +4,9 @@ import java.io.File
 
 import com.coxautodata.waimak.dataflow.{ActionResult, _}
 import org.apache.commons.io.FileUtils
-import org.apache.hadoop.fs.FileAlreadyExistsException
-import org.apache.spark.sql.{AnalysisException, Dataset}
+import org.apache.hadoop.fs.{FileAlreadyExistsException, Path}
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{AnalysisException, Dataset, SparkSession}
 
 import scala.util.Try
 
@@ -570,7 +570,6 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
 
       it("tag dependency conflicting with input dependency") {
         val spark = sparkSession
-        import spark.implicits._
         val baseDest = testingBaseDir + "/dest"
 
         val flow = Waimak.sparkFlow(sparkSession, tmpDir.toString)
@@ -597,7 +596,6 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
 
       it("tag dependent action depends on an action that does not run and therefore does not run") {
         val spark = sparkSession
-        import spark.implicits._
         val baseDest = testingBaseDir + "/dest"
 
         val flow = Waimak.sparkFlow(sparkSession, tmpDir.toString)
@@ -685,6 +683,28 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
     }
   }
 
+  describe("prepareForExecution") {
+    it("Should create a filesystem object different to the one specified in the defaultFS and create a temp folder on the overridden fs") {
+
+      // Spark session with defaultFS set to something other than file
+      val spark = SparkSession
+        .builder()
+        .appName(appName)
+        .master(master)
+        .config("spark.executor.memory", "2g")
+        .config("spark.ui.enabled", "false")
+        .getOrCreate()
+      spark.sparkContext.hadoopConfiguration.set("fs.defaultFS", "hdfs://localhost/")
+
+      // Set the waimak defaultFS for the Spark Flow Context
+      spark.conf.set("spark.waimak.fs.defaultFS", "file:///")
+      val emptyFlow = Waimak.sparkFlow(spark, new Path("file://" + testingBaseDir.toAbsolutePath.toString + "/tmp").toString)
+      emptyFlow.prepareForExecution()
+
+      emptyFlow.flowContext.fileSystem.getUri.toString should be ("file:///")
+
+    }
+  }
 
   describe("mixing multiple types in flow") {
 

--- a/waimak-impala/pom.xml
+++ b/waimak-impala/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-rdbm-export/pom.xml
+++ b/waimak-rdbm-export/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-rdbm-ingestion/pom.xml
+++ b/waimak-rdbm-ingestion/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-storage/pom.xml
+++ b/waimak-storage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
# Description

This fixes #18 .

Allow a user to override a default FS value for SparkFlowContext using spark.waimak.fs.defaultFS

Fixes # (issue)
#18 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unit test.

Please describe the tests that you have included to verify your changes

I'll run on a snapshot release to test further ADL issues/

**I'll manually merge/finish the hotfix after the PR is approved**