### PR TITLE
Hotfix/1.4.3 - Fix thread leak in storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ Other versions of Spark 2.x are also likely to work and can be added to the list
 
 ## Changelog
 
+### 1.4.3 - 2018-08-13
+
+#### Fixed
+- Azure Table uploader will now clean up thread pools to prevent exhausting system threads after being invoked multiple times
+
+### 1.4.2 - 2018-08-06
+
+#### Added
+- Added optional Spark parameter `spark.waimak.fs.defaultFS` to specify the URI of the FileSystem object in the [`SparkFlowContext`](src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala)
+
 ### 1.4.1 - 2018-07-27
 
 #### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.coxautodata</groupId>
     <artifactId>waimak-parent_2.11</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
 
     <name>Waimak</name>
     <description>An open-source tool that helps data teams row their own boats. Copyright 2018 Cox Automotive UK

--- a/waimak-azure-table/pom.xml
+++ b/waimak-azure-table/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-azure-table/src/main/scala/com/coxautodata/waimak/azure/table/SparkAzureTable.scala
+++ b/waimak-azure-table/src/main/scala/com/coxautodata/waimak/azure/table/SparkAzureTable.scala
@@ -3,6 +3,7 @@ package com.coxautodata.waimak.azure.table
 import java.util
 import java.util.concurrent.TimeUnit
 
+import com.coxautodata.waimak.azure.table.SparkAzureTable.{azureWriterOutputLabel, createIfNotExists, pushToTable}
 import com.coxautodata.waimak.dataflow.spark.SparkActions._
 import com.coxautodata.waimak.dataflow.spark.{SimpleAction, SparkDataFlow}
 import com.coxautodata.waimak.dataflow.{ActionResult, DataFlowEntities, DataFlowException}
@@ -11,7 +12,6 @@ import com.microsoft.azure.storage.table.{DynamicTableEntity, EntityProperty}
 import com.microsoft.azure.storage.{CloudStorageAccount, StorageException}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
-import com.coxautodata.waimak.azure.table.SparkAzureTable.{azureWriterOutputLabel, createIfNotExists, pushToTable}
 
 /**
   * Created by Alexei Perelighin on 2018/03/25.
@@ -83,7 +83,11 @@ object SparkAzureTable extends Logging {
       sit.foreach {
         insertBatch: Seq[DynamicTableEntity] =>
           while (!writer.queue.offer(insertBatch, 500, TimeUnit.MILLISECONDS)) {
-            if (writer.threadFailed.get()) throw new DataFlowException(s"Thread failure when writing to the Azure Table")
+            if (writer.threadFailed.get()) {
+              writer.queue.clear()
+              writer.threadPool.shutdown()
+              throw new DataFlowException(s"Thread failure when writing to the Azure Table")
+            }
           }
 
       }

--- a/waimak-configuration/pom.xml
+++ b/waimak-configuration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-core/pom.xml
+++ b/waimak-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-impala/pom.xml
+++ b/waimak-impala/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-rdbm-export/pom.xml
+++ b/waimak-rdbm-export/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-rdbm-ingestion/pom.xml
+++ b/waimak-rdbm-ingestion/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-storage/pom.xml
+++ b/waimak-storage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
# Description

This adds an explicit cleanup on thread pools since they will not be destroyed until the GC is called. In some cases, this is not quick enough and the uploaded exhausts the number of available threads of the user.

Fixes #23 Azure table uploader spawning too many threads

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I have ran this on current high workload job, and checked `jstack`. There was a normal number of threads (~30) instead of the several thousand before.


*I will manually finish the hotfix after the PR is approved*