### PR TITLE
Hotfix/1.5.1 Impala JDBC change for extra Properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ cache:
 
 matrix:
   include:
-    - env: MAVEN_PROFILE="apache-2.0.0"
-    - env: MAVEN_PROFILE="apache-2.1.0"
     - env: MAVEN_PROFILE="apache-2.2.0" DEPLOY_PROFILE="true" COVERAGE_PROFILE="true"
     - env: MAVEN_PROFILE="apache-2.3.0"
     - env: MAVEN_PROFILE="cloudera-2.2.0.cloudera1"

--- a/README.md
+++ b/README.md
@@ -86,15 +86,21 @@ Waimak is tested against the following versions of Spark:
 
 Package Maintainer | Spark Version
 ------------------ | -------------
-Apache Spark | [2.0.0](https://spark.apache.org/releases/spark-release-2-0-0.html)
-Apache Spark | [2.1.0](https://spark.apache.org/releases/spark-release-2-1-0.html)
 Apache Spark | [2.2.0](https://spark.apache.org/releases/spark-release-2-2-0.html)
 Apache Spark | [2.3.0](https://spark.apache.org/releases/spark-release-2-3-0.html)
 Cloudera Spark | [2.2.0](https://www.cloudera.com/documentation/spark2/latest/topics/spark2.html)
 
-Other versions of Spark 2.x are also likely to work and can be added to the list of tested versions if there is sufficient need.
+Other versions of Spark >= 2.2 are also likely to work and can be added to the list of tested versions if there is sufficient need.
 
 ## Changelog
+
+### 1.5.1 - 2018-08-21
+
+#### Added
+- Support of custom properties for JDBC connections using the Metastore Utils by passing either a `Properties` object or a `Map` so they can be read securely from a `JCEKS` file
+
+#### Removed
+- Removed support for Spark 2.0 and Spark 2.1
 
 ### 1.5 - 2018-08-13
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.coxautodata</groupId>
     <artifactId>waimak-parent_2.11</artifactId>
     <packaging>pom</packaging>
-    <version>1.5</version>
+    <version>1.5.1-SNAPSHOT</version>
 
     <name>Waimak</name>
     <description>An open-source tool that helps data teams row their own boats. Copyright 2018 Cox Automotive UK

--- a/pom.xml
+++ b/pom.xml
@@ -78,22 +78,6 @@
     <profiles>
         <!-- Spark profiles -->
         <profile>
-            <id>apache-2.0.0</id>
-            <properties>
-                <spark.version>2.0.0</spark.version>
-                <scala.compatible.version>2.11</scala.compatible.version>
-                <scala.lang.version>2.11.8</scala.lang.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>apache-2.1.0</id>
-            <properties>
-                <spark.version>2.1.0</spark.version>
-                <scala.compatible.version>2.11</scala.compatible.version>
-                <scala.lang.version>2.11.8</scala.lang.version>
-            </properties>
-        </profile>
-        <profile>
             <id>apache-2.2.0</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/waimak-azure-table/pom.xml
+++ b/waimak-azure-table/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-configuration/pom.xml
+++ b/waimak-configuration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-core/pom.xml
+++ b/waimak-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/metastore/MetastoreUtils.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/metastore/MetastoreUtils.scala
@@ -1,11 +1,9 @@
 package com.coxautodata.waimak.metastore
 
-import java.sql.{DriverManager, ResultSet}
-
+import java.sql.{Connection, DriverManager, ResultSet}
 import com.coxautodata.waimak.dataflow.DataFlowException
-import com.coxautodata.waimak.dataflow.spark.SparkFlowContext
 import com.coxautodata.waimak.log.Logging
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
 
 /**
@@ -69,10 +67,45 @@ trait JDBCConnector extends DBConnector {
     */
   def jdbcString: String
 
-  override private[metastore] def runQueries(ddls: Seq[String]): Seq[Option[ResultSet]] = {
+  /**
+    * Key value pairs passed as connection arguments to the DriverManager during connection
+    */
+  def properties: java.util.Properties
+
+  /**
+    * Key value set of parameters used to get parameter values for JDBC properties
+    * from a secure jceks file at CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH.
+    * First value is the key of the parameter in the jceks file and the second parameter
+    * is the key of the parameter you want in jdbc properties
+    *
+    * @return
+    */
+  def secureProperties: Map[String, String]
+
+  /**
+    * Hadoop configuration object. Used to access secure credentials.
+    */
+  def hadoopConfiguration: Configuration
+
+  private[metastore] def getAllProperties: java.util.Properties = {
+    // Construct new properties and copy over existing to maintain immutability
+    val newProps = new java.util.Properties()
+    newProps.putAll(properties)
+
+    secureProperties.foldLeft(newProps) {
+      case (props, (jcekKey, jdbcKey)) =>
+        props.setProperty(jdbcKey, hadoopConfiguration.getPassword(jcekKey).mkString)
+        props
+    }
+  }
+
+  private def getConnection: Connection = {
     Class.forName(driverName)
-    val connection = DriverManager.getConnection(jdbcString, "", "")
-    val statement = connection.createStatement
+    DriverManager.getConnection(jdbcString, getAllProperties)
+  }
+
+  override private[metastore] def runQueries(ddls: Seq[String]): Seq[Option[ResultSet]] = {
+    val statement = getConnection.createStatement
     ddls.map(ddl => {
       logInfo(s"Submitting query to $jdbcString: $ddl")
       val submit = statement.execute(ddl)

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/metastore/TestMetastoreUtils.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/metastore/TestMetastoreUtils.scala
@@ -1,0 +1,68 @@
+package com.coxautodata.waimak.metastore
+
+import java.util.Properties
+
+import com.coxautodata.waimak.dataflow.spark.SparkAndTmpDirSpec
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.alias.CredentialProviderFactory
+import org.apache.spark.sql.SparkSession
+import scala.collection.JavaConversions._
+
+class TestMetastoreUtils extends SparkAndTmpDirSpec {
+  override val appName: String = "Metastore Tests"
+
+  describe("JDBCConnector") {
+    it("Should get jdbc properties from jceks file and combine them with existing properties") {
+
+      // Create local jceks file and put entries in
+      val jceksFile = s"jceks://file$testingBaseDirName/creds.jceks"
+      val entries = Map("user" -> "ringo", "password" -> "starr")
+      createJceksWithEntries(jceksFile, entries, sparkSession.sparkContext.hadoopConfiguration)
+
+      val jdbcMapping = Map("user" -> "jdbc.user", "password" -> "jdbc.password")
+      val properties = new Properties()
+      properties.setProperty("jdbc.timeout", "1")
+
+      val jdbc = TestJDBCConnector(sparkSession, properties, jdbcMapping)
+
+      jdbc.getAllProperties.toMap should contain theSameElementsAs Map("jdbc.user" -> "ringo", "jdbc.password" -> "starr", "jdbc.timeout" -> "1")
+
+      // Test immutability
+      jdbc.properties.toMap should contain theSameElementsAs Map("jdbc.timeout" -> "1")
+
+    }
+
+    it("Should not get properties from the jceks path if none are given") {
+
+      val properties = new Properties()
+      properties.setProperty("jdbc.timeout", "1")
+
+      val jdbc = TestJDBCConnector(sparkSession, properties)
+
+      jdbc.getAllProperties.toMap should contain theSameElementsAs Map("jdbc.timeout" -> "1")
+      jdbc.properties.toMap should contain theSameElementsAs Map("jdbc.timeout" -> "1")
+
+    }
+  }
+
+  def createJceksWithEntries(jceksURL: String, entries: Map[String, String], conf: Configuration): Unit = {
+    conf.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, jceksURL)
+    val provider = CredentialProviderFactory.getProviders(conf).get(0)
+    entries.foreach {
+      case (k, v) => provider.createCredentialEntry(k, v.toCharArray)
+    }
+    provider.flush()
+  }
+
+}
+
+
+case class TestJDBCConnector(sparkSession: SparkSession,
+                             properties: Properties = new Properties(),
+                             secureProperties: Map[String, String] = Map.empty) extends JDBCConnector {
+  override def driverName: String = ???
+
+  override def jdbcString: String = ???
+
+  override def hadoopConfiguration: Configuration = sparkSession.sparkContext.hadoopConfiguration
+}

--- a/waimak-impala/pom.xml
+++ b/waimak-impala/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
+++ b/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
@@ -4,6 +4,7 @@ import java.sql.ResultSet
 
 import com.coxautodata.waimak.dataflow.DataFlowException
 import com.coxautodata.waimak.dataflow.spark.SparkFlowContext
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
@@ -51,10 +52,17 @@ trait ImpalaDBConnector extends HadoopDBConnector {
   * @param database     name of the database to connect to
   * @param cluster      the cluster label in the JDBC template string
   */
-case class ImpalaWaimakJDBCConnector(sparkSession: SparkSession, database: String, cluster: String = "default", forceRecreateTables: Boolean = false) extends ImpalaDBConnector with WaimakJDBCConnector {
+case class ImpalaWaimakJDBCConnector(sparkSession: SparkSession,
+                                     database: String,
+                                     cluster: String = "default",
+                                     forceRecreateTables: Boolean = false,
+                                     properties: java.util.Properties = new java.util.Properties(),
+                                     secureProperties: Map[String, String] = Map.empty) extends ImpalaDBConnector with WaimakJDBCConnector {
   override val driverName: String = "org.apache.hive.jdbc.HiveDriver"
   override val sparkConf: SparkConf = sparkSession.sparkContext.getConf
   override val service: String = "impala"
+
+  override def hadoopConfiguration: Configuration = sparkSession.sparkContext.hadoopConfiguration
 }
 
 /**
@@ -63,8 +71,14 @@ case class ImpalaWaimakJDBCConnector(sparkSession: SparkSession, database: Strin
   * @param sparkSession SparkSession object
   * @param jdbcString   the JDBC connection string
   */
-case class ImpalaJDBCConnector(sparkSession: SparkSession, jdbcString: String, forceRecreateTables: Boolean = false) extends ImpalaDBConnector with JDBCConnector {
+case class ImpalaJDBCConnector(sparkSession: SparkSession,
+                               jdbcString: String,
+                               forceRecreateTables: Boolean,
+                               properties: java.util.Properties = new java.util.Properties(),
+                               secureProperties: Map[String, String] = Map.empty) extends ImpalaDBConnector with JDBCConnector {
   override val driverName: String = "org.apache.hive.jdbc.HiveDriver"
+
+  override def hadoopConfiguration: Configuration = sparkSession.sparkContext.hadoopConfiguration
 }
 
 /**

--- a/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
+++ b/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
@@ -66,14 +66,14 @@ case class ImpalaWaimakJDBCConnector(sparkSession: SparkSession,
 }
 
 /**
-  * Impala Database connector that is contructed from a JDBC connection string
+  * Impala Database connector that is constructed from a JDBC connection string
   *
   * @param sparkSession SparkSession object
   * @param jdbcString   the JDBC connection string
   */
 case class ImpalaJDBCConnector(sparkSession: SparkSession,
                                jdbcString: String,
-                               forceRecreateTables: Boolean,
+                               forceRecreateTables: Boolean = false,
                                properties: java.util.Properties = new java.util.Properties(),
                                secureProperties: Map[String, String] = Map.empty) extends ImpalaDBConnector with JDBCConnector {
   override val driverName: String = "org.apache.hive.jdbc.HiveDriver"

--- a/waimak-rdbm-export/pom.xml
+++ b/waimak-rdbm-export/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-rdbm-ingestion/pom.xml
+++ b/waimak-rdbm-ingestion/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/waimak-storage/pom.xml
+++ b/waimak-storage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>waimak-parent_2.11</artifactId>
         <groupId>com.coxautodata</groupId>
-        <version>1.5</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
# Description

All generic properties in JDBC connection objects, and add capability of using secure properties from a jceks file.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Default values have been added to any existing case classes that I have changed meaning there should be no breaking API change.

# How Has This Been Tested?

Added unit tests.

I'll test this on a JDBC connector internally once someone is happy with the approach.

*I'll finish the hotfix/merge manually once approved*