### PR TITLE
Fix for action exceptions causing application to hang 

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowExecutor.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlowExecutor.scala
@@ -129,7 +129,7 @@ trait DataFlowExecutor[C] extends Logging {
         logError("Failed Action " + t._1.logLabel + " " + t._2.failed)
       }
       failed.head._2.asInstanceOf[Try[(DataFlow[C], Seq[DataFlowAction[C]])]]
-      Failure(throw new DataFlowException(s"Exception performing action: ${failed.head._1.logLabel}", failed.head._2.failed.get))
+      Failure(new DataFlowException(s"Exception performing action: ${failed.head._1.logLabel}", failed.head._2.failed.get))
     }
   }
 


### PR DESCRIPTION
# Description

Exceptions were being thrown from failed actions before the executor had cleaned up the execution pools, resulting in the application hanging

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally to verify hanging is no longer happening when an exception is thrown within an action
