### PR TITLE
Upgrade Scala 2.11 compiler and add 2.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - env: MAVEN_PROFILE="cloudera-2.2.0.cloudera1_2.11" SCALA_VERSION="2.11"
 
 before_install:
-  - sh dev/change-scala-version.sh "$SCALA_VERSION"
+  - bash dev/change-scala-version.sh "$SCALA_VERSION"
 
 install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -P$MAVEN_PROFILE -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ cache:
 
 matrix:
   include:
-    - env: MAVEN_PROFILE="apache-2.2.0" DEPLOY_PROFILE="true" COVERAGE_PROFILE="true"
-    - env: MAVEN_PROFILE="apache-2.3.0"
-    - env: MAVEN_PROFILE="cloudera-2.2.0.cloudera1"
+    - env: MAVEN_PROFILE="apache-2.2.0_2.11" DEPLOY_PROFILE="true" COVERAGE_PROFILE="true" SCALA_VERSION="2.11"
+    - env: MAVEN_PROFILE="apache-2.3.0_2.11" SCALA_VERSION="2.11"
+    - env: MAVEN_PROFILE="apache-2.4.0_2.11" SCALA_VERSION="2.11"
+    - env: MAVEN_PROFILE="apache-2.4.0_2.12" DEPLOY_PROFILE="true" SCALA_VERSION="2.12"
+    - env: MAVEN_PROFILE="cloudera-2.2.0.cloudera1_2.11" SCALA_VERSION="2.11"
+
+before_install:
+  - sh dev/change-scala-version.sh "$SCALA_VERSION"
 
 install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -P$MAVEN_PROFILE -U

--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ Artifact ID | Purpose | Maven Release
 
 Waimak is tested against the following versions of Spark:
 
-Package Maintainer | Spark Version
------------------- | -------------
-Apache Spark | [2.2.0](https://spark.apache.org/releases/spark-release-2-2-0.html)
-Apache Spark | [2.3.0](https://spark.apache.org/releases/spark-release-2-3-0.html)
-Cloudera Spark | [2.2.0](https://www.cloudera.com/documentation/spark2/latest/topics/spark2.html)
+Package Maintainer | Spark Version | Scala Version
+------------------ | ------------- | -------------
+Apache Spark | [2.2.0](https://spark.apache.org/releases/spark-release-2-2-0.html) | 2.11
+Apache Spark | [2.3.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.11
+Apache Spark | [2.4.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.11
+Apache Spark | [2.4.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.12
+Cloudera Spark | [2.2.0](https://www.cloudera.com/documentation/spark2/latest/topics/spark2.html) | 2.11
 
 Other versions of Spark >= 2.2 are also likely to work and can be added to the list of tested versions if there is sufficient need.
 
@@ -151,7 +153,7 @@ We welcome all users to contribute to the development of Waimak by raising pull-
 
 ### Testing
 
-Waimak is tested against different versions of Spark 2.x to ensure uniform compatibility. The versions of Spark tested by Waimak are given in the `<profiles>` section of the POM. You can activate a given profile in the POM by using the `-P` flag: `mvn clean package -P apache-2.3.0`
+Waimak is tested against different versions of Spark 2.x to ensure uniform compatibility. The versions of Spark tested by Waimak are given in the `<profiles>` section of the POM. You can activate a given profile in the POM by using the `-P` flag: `mvn clean package -P apache-2.3.0_2.11`
 
 The integration tests of the RDBM ingestion module require Docker therefore you must have the Docker service running and the current user must be able to access the Docker service.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Package Maintainer | Spark Version | Scala Version
 Apache Spark | [2.2.0](https://spark.apache.org/releases/spark-release-2-2-0.html) | 2.11
 Apache Spark | [2.3.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.11
 Apache Spark | [2.4.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.11
-Apache Spark | [2.4.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.12
+Apache Spark | [2.4.0](https://spark.apache.org/releases/spark-release-2-3-0.html) | 2.12 (experimental)
 Cloudera Spark | [2.2.0](https://www.cloudera.com/documentation/spark2/latest/topics/spark2.html) | 2.11
 
 Other versions of Spark >= 2.2 are also likely to work and can be added to the list of tested versions if there is sufficient need.

--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+VALID_VERSIONS=( 2.11 2.12 )
+
+usage() {
+  echo "Usage: $(basename $0) [-h|--help] <version>
+where :
+  -h| --help Display this help text
+  valid version values : ${VALID_VERSIONS[*]}
+" 1>&2
+  exit 1
+}
+
+if [[ ($# -ne 1) || ( $1 == "--help") ||  $1 == "-h" ]]; then
+  usage
+fi
+
+TO_VERSION=$1
+
+check_scala_version() {
+  for i in ${VALID_VERSIONS[*]}; do [ $i = "$1" ] && return 0; done
+  echo "Invalid Scala version: $1. Valid versions: ${VALID_VERSIONS[*]}" 1>&2
+  exit 1
+}
+
+check_scala_version "$TO_VERSION"
+
+if [ $TO_VERSION = "2.11" ]; then
+  FROM_VERSION="2.12"
+else
+  FROM_VERSION="2.11"
+fi
+
+sed_i() {
+  sed -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+}
+
+export -f sed_i
+
+BASEDIR=$(dirname $0)/..
+find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' {}" \;

--- a/pom.xml
+++ b/pom.xml
@@ -78,30 +78,46 @@
     <profiles>
         <!-- Spark profiles -->
         <profile>
-            <id>apache-2.2.0</id>
+            <id>apache-2.2.0_2.11</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
                 <spark.version>2.2.0</spark.version>
                 <scala.compatible.version>2.11</scala.compatible.version>
-                <scala.lang.version>2.11.8</scala.lang.version>
+                <scala.lang.version>2.11.12</scala.lang.version>
             </properties>
         </profile>
         <profile>
-            <id>apache-2.3.0</id>
+            <id>apache-2.3.0_2.11</id>
             <properties>
                 <spark.version>2.3.0</spark.version>
                 <scala.compatible.version>2.11</scala.compatible.version>
-                <scala.lang.version>2.11.8</scala.lang.version>
+                <scala.lang.version>2.11.12</scala.lang.version>
             </properties>
         </profile>
         <profile>
-            <id>cloudera-2.2.0.cloudera1</id>
+            <id>apache-2.4.0_2.11</id>
+            <properties>
+                <spark.version>2.4.0</spark.version>
+                <scala.compatible.version>2.11</scala.compatible.version>
+                <scala.lang.version>2.11.12</scala.lang.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>apache-2.4.0_2.12</id>
+            <properties>
+                <spark.version>2.4.0</spark.version>
+                <scala.compatible.version>2.12</scala.compatible.version>
+                <scala.lang.version>2.12.7</scala.lang.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>cloudera-2.2.0.cloudera1_2.11</id>
             <properties>
                 <spark.version>2.2.0.cloudera1</spark.version>
                 <scala.compatible.version>2.11</scala.compatible.version>
-                <scala.lang.version>2.11.8</scala.lang.version>
+                <scala.lang.version>2.11.12</scala.lang.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,17 @@
                 <scala.compatible.version>2.12</scala.compatible.version>
                 <scala.lang.version>2.12.7</scala.lang.version>
             </properties>
+            <dependencies>
+                <!-- Temporary fix as avro still seems to be pulling in a broken paranamer version
+                https://jira.apache.org/jira/browse/SPARK-22128
+                -->
+                <dependency>
+                    <groupId>com.thoughtworks.paranamer</groupId>
+                    <artifactId>paranamer</artifactId>
+                    <version>2.8</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>cloudera-2.2.0.cloudera1_2.11</id>

--- a/waimak-configuration/pom.xml
+++ b/waimak-configuration/pom.xml
@@ -28,6 +28,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.lang.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.coxautodata</groupId>
             <artifactId>waimak-core_2.11</artifactId>
             <version>${project.parent.version}</version>

--- a/waimak-configuration/src/test/scala/com/coxautodata/waimak/configuration/TestCaseClassConfigParser.scala
+++ b/waimak-configuration/src/test/scala/com/coxautodata/waimak/configuration/TestCaseClassConfigParser.scala
@@ -187,7 +187,6 @@ class TestCaseClassConfigParser extends FunSpec with Matchers {
     }
 
     it("parsing a case class nested in a class should throw an exception with a helpful error") {
-      case class ParseNestedClassTest(string: String = "")
       val conf: SparkConf = new SparkConf()
       intercept[UnsupportedOperationException] {
         CaseClassConfigParser[ParseNestedClassTest](conf, "")
@@ -203,5 +202,7 @@ class TestCaseClassConfigParser extends FunSpec with Matchers {
     }
 
   }
+
+  case class ParseNestedClassTest(string: String = "")
 
 }


### PR DESCRIPTION
# Description
This fixes the security warning in Github by upgrading the scala 2.11 compiler and adds experimental 2.12 support with the release of [Spark 2.4](https://spark.apache.org/releases/spark-release-2-4-0.html).

I have build a snapshot version here, showing 2.12 version with correct package names:
[https://oss.sonatype.org/content/repositories/snapshots/com/coxautodata/waimak-core_2.12/](https://oss.sonatype.org/content/repositories/snapshots/com/coxautodata/waimak-core_2.12/)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unit testing.