### PR TITLE
Added exception for bad sql label names

### DIFF
--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSimpleSparkDataFlow.scala
@@ -243,6 +243,18 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
       finalState.inputs.size should be(5)
       finalState.inputs.getOption[Dataset[_]]("report").map(_.as[TReport].collect()).get should be(report)
     }
+
+    it("invalid label name") {
+      val spark = sparkSession
+      val res = intercept[DataFlowException] {
+        Waimak.sparkFlow(spark)
+          .openCSV(basePath)("csv_1")
+          .alias("csv_1", "bad-name")
+          .sql("bad-name")("bad-output", "select * from bad-name")
+      }
+      res.text should be ("The following labels contain invalid characters to be used as Spark SQL view names: [bad-name]. " +
+        "You can alias the label to a valid name before calling the sql action.")
+    }
   }
 
   describe("joins") {
@@ -746,6 +758,18 @@ class TestSimpleSparkDataFlow extends SparkAndTmpDirSpec {
 
       val csv_2_sql = spark.sql("select * from csv_2")
       csv_2_sql.as[TPerson].collect() should be(persons)
+    }
+
+    it("invalid label name") {
+      val spark = sparkSession
+      val res = intercept[DataFlowException] {
+        Waimak.sparkFlow(spark)
+          .openCSV(basePath)("csv_1")
+          .alias("csv_1", "bad-name")
+          .debugAsTable("bad-name")
+      }
+      res.text should be ("The following labels contain invalid characters to be used as Spark SQL view names: [bad-name]. " +
+        "You can alias the label to a valid name before calling the debugAsTable action.")
     }
 
   }


### PR DESCRIPTION
# Description

Adds a more useful exception for invalid label names when used as temp views.

Fixes https://github.com/CoxAutomotiveDataSolutions/waimak/issues/29

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests