### PR TITLE
Made various storage options configurable

### DIFF
--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkData.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkData.scala
@@ -60,6 +60,7 @@ object TestSparkData {
   val lastTS_4 = new Timestamp(formatter.parse("2018-01-04 00:00").getTime)
   val lastTS_5 = new Timestamp(formatter.parse("2018-01-05 00:00").getTime)
   val lastTS_6 = new Timestamp(formatter.parse("2018-01-06 00:00").getTime)
+  val lastTS_7 = new Timestamp(formatter.parse("2018-01-07 00:00").getTime)
 
 
   val persons_evolved_compacted_1 = Seq(

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
@@ -47,8 +47,7 @@ object RDBMIngestionActions {
                                  , extractDateTime: ZonedDateTime
                                  , lastUpdatedOffset: Long = 0
                                  , forceFullLoad: Boolean = false
-                                 , doCompaction: (Seq[AuditTableRegionInfo], Long, ZonedDateTime) => Boolean = (_, _, _) => false
-                                 , trashMaxAge: Duration = Duration.ofHours(24))(tables: String*): SparkDataFlow = {
+                                 , doCompaction: (Seq[AuditTableRegionInfo], Long, ZonedDateTime) => Boolean = (_, _, _) => false)(tables: String*): SparkDataFlow = {
 
       val basePath = new Path(storageBasePath)
 
@@ -87,7 +86,7 @@ object RDBMIngestionActions {
           , table.tableName
           , tableConfigs(table.tableName).maxRowsPerPartition
           , forceFullLoad)
-          .writeToStorage(table.tableName, table, rdbmExtractor.rdbmRecordLastUpdatedColumn, extractDateTime, doCompaction, trashMaxAge)
+          .writeToStorage(table.tableName, table, rdbmExtractor.rdbmRecordLastUpdatedColumn, extractDateTime, doCompaction)
       })
     }
 

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
@@ -91,13 +91,13 @@ trait AuditTable {
     * @param compactTS               timestamp of when the compaction is requested, will not be used for any filtering of the data
     * @param trashMaxAge             Maximum age of old region files kept in the .Trash folder
     *                                after a compaction has happened.
-    * @param smallRegionRowThreshold the row number threshold to use for determinining small regions to be compacted.
+    * @param smallRegionRowThreshold the row number threshold to use for determining small regions to be compacted.
     *                                Default is 50000000
     * @param hotCellsPerPartition    approximate maximum number of cells (numRows * numColumns) to be in each hot partition file.
     *                                Adjust this to control output file size. Default is 1000000
     * @param coldCellsPerPartition   approximate maximum number of cells (numRows * numColumns) to be in each cold partition file.
     *                                Adjust this to control output file size. Default is 2500000
-    * @param recompactAll            Whether to recompact all regions regardless of size (i.e. ignore smallRegionRowThreshold
+    * @param recompactAll            Whether to recompact all regions regardless of size (i.e. ignore smallRegionRowThreshold)
     * @return new state of the AuditTable
     */
   def compact(compactTS: Timestamp

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
@@ -97,13 +97,15 @@ trait AuditTable {
     *                                Adjust this to control output file size. Default is 1000000
     * @param coldCellsPerPartition   approximate maximum number of cells (numRows * numColumns) to be in each cold partition file.
     *                                Adjust this to control output file size. Default is 2500000
+    * @param recompactAll            Whether to recompact all regions regardless of size (i.e. ignore smallRegionRowThreshold
     * @return new state of the AuditTable
     */
   def compact(compactTS: Timestamp
               , trashMaxAge: Duration
               , smallRegionRowThreshold: Int = 50000000
               , hotCellsPerPartition: Int = 1000000
-              , coldCellsPerPartition: Int = 2500000): Try[AuditTable]
+              , coldCellsPerPartition: Int = 2500000
+              , recompactAll: Boolean = false): Try[AuditTable]
 
   /**
     * Returns latest timestamp of records stored in the audit table.

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
@@ -88,12 +88,13 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     * @param compactTS               timestamp of when the compaction is requested, will not be used for any filtering of the data
     * @param trashMaxAge             Maximum age of old region files kept in the .Trash folder
     *                                after a compaction has happened.
-    * @param smallRegionRowThreshold the row number threshold to use for determinining small regions to be compacted.
+    * @param smallRegionRowThreshold the row number threshold to use for determining small regions to be compacted.
     *                                Default is 50000000
     * @param hotCellsPerPartition    approximate maximum number of cells (numRows * numColumns) to be in each hot partition file.
     *                                Adjust this to control output file size. Default is 1000000
     * @param coldCellsPerPartition   approximate maximum number of cells (numRows * numColumns) to be in each cold partition file.
     *                                Adjust this to control output file size. Default is 2500000
+    * @param recompactAll            Whether to recompact all regions regardless of size (i.e. ignore smallRegionRowThreshold)
     * @return new state of the AuditTable
     */
   override def compact(compactTS: Timestamp

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
@@ -96,10 +96,15 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     *                                Adjust this to control output file size. Default is 2500000
     * @return new state of the AuditTable
     */
-  override def compact(compactTS: Timestamp, trashMaxAge: Duration, smallRegionRowThreshold: Int, hotCellsPerPartition: Int, coldCellsPerPartition: Int): Try[AuditTable] = {
+  override def compact(compactTS: Timestamp
+                       , trashMaxAge: Duration
+                       , smallRegionRowThreshold: Int
+                       , hotCellsPerPartition: Int
+                       , coldCellsPerPartition: Int
+                       , recompactAll: Boolean): Try[AuditTable] = {
     val res: Try[AuditTableFile] = Try(markToUpdate())
       .flatMap(_ => commitHotToCold(compactTS, hotCellsPerPartition))
-      .flatMap(_.compactCold(compactTS, smallRegionRowThreshold, coldCellsPerPartition))
+      .flatMap(_.compactCold(compactTS, smallRegionRowThreshold, coldCellsPerPartition, recompactAll))
       .map { f =>
         f.storageOps.purgeTrash(f.tableName, compactTS, trashMaxAge)
         f
@@ -159,10 +164,15 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     *                                Adjust this to control output file size.
     * @return
     */
-  protected def compactCold(compactTS: Timestamp, smallRegionRowThreshold: Int, cellsPerPartition: Int): Try[AuditTableFile] = {
-    val smallerRegions = regions.filter(r => r.store_type == COLD_PARTITION && r.count < smallRegionRowThreshold)
+  protected def compactCold(compactTS: Timestamp
+                            , smallRegionRowThreshold: Int
+                            , cellsPerPartition: Int
+                            , recompactAll: Boolean): Try[AuditTableFile] = {
+    val smallerRegions =
+      if (recompactAll) regions
+      else regions.filter(r => r.store_type == COLD_PARTITION && r.count < smallRegionRowThreshold)
     // No use compacting a single small region into itself
-    compactRegions(coldPath, if (smallerRegions.length < 2) Seq.empty else smallerRegions, compactTS, cellsPerPartition)
+    compactRegions(coldPath, if (smallerRegions.length < 2 && !recompactAll) Seq.empty else smallerRegions, compactTS, cellsPerPartition)
   }
 
   protected def compactRegions(typePath: Path

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
@@ -254,6 +254,10 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
       fourthCompact.regions(0).store_region should be("6")
       new File(trashBinPath.toString, tableName).list() should contain theSameElementsAs Seq()
 
+      //Request to recompact all should force single cold region to be recompacted
+      val fifthCompact = fourthCompact.compact(lastTS_7, d3d, recompactAll = true).get
+      fifthCompact.regions.size should be(1)
+      fifthCompact.regions(0).store_region should be("7")
     }
 
     it("single compact into new with schema evolution on hot") {


### PR DESCRIPTION
# Description

Made various storage layer options configurable via the Spark configuration:
`spark.waimak.storage.trashMaxAgeMs`: Maximum age in ms of old region files kept in the .Trash folder after a compaction has happened. Default is `86400000`
`spark.waimak.storage.smallRegionRowThreshold`: The row number threshold to use for determining small regions to be compacted. Default is `50000000`
`spark.waimak.storage.hotCellsPerPartition`: Approximate maximum number of cells (numRows * numColumns) to be in each hot partition file. Adjust this to control output file size. Default is `1000000`
`spark.waimak.storage.coldCellsPerPartition`:  Approximate maximum number of cells (numRows * numColumns) to be in each cold partition file. Adjust this to control output file size. Default is `2500000`
`spark.waimak.storage.recompactAll`: Whether to recompact all regions regardless of size. Default is` false`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Existing unit tests plus a test to verify `recompactAll` forces recompaction of old cold regions
