### PR TITLE
Exposed uri used on the flow in the Spark context

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala
@@ -15,9 +15,9 @@ import org.apache.spark.sql.SparkSession
   */
 case class SparkFlowContext(spark: SparkSession) extends FlowContext {
 
-  private val uriToUse = spark.conf.get("spark.waimak.fs.defaultFS", spark.sparkContext.hadoopConfiguration.get("fs.defaultFS"))
+  val uriUsed: String = spark.conf.get("spark.waimak.fs.defaultFS", spark.sparkContext.hadoopConfiguration.get("fs.defaultFS"))
 
-  lazy val fileSystem: FileSystem = FileSystem.get(new URI(uriToUse), spark.sparkContext.hadoopConfiguration)
+  lazy val fileSystem: FileSystem = FileSystem.get(new URI(uriUsed), spark.sparkContext.hadoopConfiguration)
 
   override def setPoolIntoContext(poolName: String): Unit = spark.sparkContext.setLocalProperty("spark.scheduler.pool", poolName)
 

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
@@ -790,6 +790,7 @@ class TestSparkDataFlow extends SparkAndTmpDirSpec {
 
       // Test the flow filesystem differs from what the default one would be
       emptyFlow.flowContext.fileSystem.getUri.toString should be("file:///")
+      emptyFlow.flowContext.uriUsed.toString should be("file:///")
       FileSystem.get(spark.sparkContext.hadoopConfiguration).getUri.toString should be("hdfs://localhost")
     }
   }


### PR DESCRIPTION
# Description

Expose the actual URI used to create the FileSystem object in the Spark Flow Context.

Fixes #47 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit test
