### PR TITLE
Issues #53 Allow repartition by integer value

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/EmptyFlowContext.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/EmptyFlowContext.scala
@@ -1,5 +1,8 @@
 package com.coxautodata.waimak.dataflow
 
+import java.util.Properties
+
+
 class EmptyFlowContext extends FlowContext {
 
   override def setPoolIntoContext(poolName: String): Unit = Unit
@@ -7,5 +10,8 @@ class EmptyFlowContext extends FlowContext {
   override def reportActionStarted(action: DataFlowAction): Unit = Unit
 
   override def reportActionFinished(action: DataFlowAction): Unit = Unit
-  
+
+  override def getOption(key: String): Option[String] = Option(conf.getProperty(key))
+
+  val conf: Properties = new Properties()
 }

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/FlowContext.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/FlowContext.scala
@@ -2,6 +2,34 @@ package com.coxautodata.waimak.dataflow
 
 trait FlowContext {
 
+  /** Get a configuration value, returning a None if not set */
+  def getOption(key: String): Option[String]
+
+  /** Get a configuration value as a string, falling back to a default if not set */
+  def getString(key: String, defaultValue: String): String = {
+    getOption(key).getOrElse(defaultValue)
+  }
+
+  /** Get a configuration value as an integer, falling back to a default if not set */
+  def getInt(key: String, defaultValue: Int): Int = {
+    getOption(key).map(_.toInt).getOrElse(defaultValue)
+  }
+
+  /** Get a configuration value as a long, falling back to a default if not set */
+  def getLong(key: String, defaultValue: Long): Long = {
+    getOption(key).map(_.toLong).getOrElse(defaultValue)
+  }
+
+  /** Get a configuration value as a double, falling back to a default if not set */
+  def getDouble(key: String, defaultValue: Double): Double = {
+    getOption(key).map(_.toDouble).getOrElse(defaultValue)
+  }
+
+  /** Get a configuration value as a boolean, falling back to a default if not set */
+  def getBoolean(key: String, defaultValue: Boolean): Boolean = {
+    getOption(key).map(_.toBoolean).getOrElse(defaultValue)
+  }
+
   def setPoolIntoContext(poolName: String): Unit
 
   def reportActionStarted(action: DataFlowAction): Unit

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/ParquetDataCommitter.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/ParquetDataCommitter.scala
@@ -66,7 +66,7 @@ case class ParquetDataCommitter(outputBaseFolder: String,
 
   private def optionallyCacheLabel(flow: SparkDataFlow, commitEntry: CommitEntry): SparkDataFlow = {
     if (flow.actions.exists(_.inputLabels.contains(commitEntry.label)))
-      flow.cacheAsPartitionedParquet(commitEntry.partitions, commitEntry.repartition)(commitEntry.label)
+      SparkInterceptors.addCacheAsParquet(flow, commitEntry.label, commitEntry.partitions, commitEntry.repartition)
     else {
       logInfo(s"Committed label [${commitEntry.label}] will not be cached even though cacheLabels hint was given as it is not used " +
         s"as input for any other actions")

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkActions.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkActions.scala
@@ -650,10 +650,10 @@ object SparkActions {
       * @param labels - list of labels to snapshot
       * @return
       */
-    def cacheAsPartitionedParquet(partitions: Option[Either[Seq[String], Int]], repartition: Boolean = true)(labels: String*): SparkDataFlow = {
+    def cacheAsPartitionedParquet(partitions: Seq[String], repartition: Boolean = true)(labels: String*): SparkDataFlow = {
       if (labels.isEmpty) throw new DataFlowException(s"At least one label must be specified for cacheAsParquet")
 
-      labels.foldLeft(sparkDataFlow) { (flow, label) => SparkInterceptors.addCacheAsParquet(flow, label, partitions, repartition) }
+      labels.foldLeft(sparkDataFlow) { (flow, label) => SparkInterceptors.addCacheAsParquet(flow, label, Some(Left(partitions)), repartition) }
     }
 
     /**

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkActions.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkActions.scala
@@ -2,7 +2,6 @@ package com.coxautodata.waimak.dataflow.spark
 
 import com.coxautodata.waimak.dataflow.{ActionResult, DataFlowEntities, DataFlowException}
 import com.coxautodata.waimak.log.Logging
-import com.coxautodata.waimak.metastore.HadoopDBConnector
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 
@@ -532,6 +531,18 @@ object SparkActions {
     }
 
     /**
+      * Writes out data set as parquet, can have partitioned columns.
+      *
+      * @param label       - label whose data set will be written out
+      * @param repartition - repartition dataframe by a number of partitions
+      * @param basePath    - base path of the label, label will be added to it
+      * @return
+      */
+    def writePartitionedParquet(basePath: String, repartition: Int)(label: String): SparkDataFlow = {
+      write(label, applyRepartition(repartition), applyWriteParquet(new Path(basePath, label).toString))
+    }
+
+    /**
       * Writes multiple datasets as parquet files into basePath. Names of the labels will become names of the folders
       * under the basePath.
       *
@@ -627,7 +638,7 @@ object SparkActions {
     def cacheAsParquet(labels: String*): SparkDataFlow = {
       if (labels.isEmpty) throw new DataFlowException(s"At least one label must be specified for cacheAsParquet")
 
-      labels.foldLeft(sparkDataFlow) { (flow, label) => SparkInterceptors.addCacheAsParquet(flow, label) }
+      labels.foldLeft(sparkDataFlow) { (flow, label) => SparkInterceptors.addCacheAsParquet(flow, label, None, repartition = false) }
     }
 
     /**
@@ -639,7 +650,7 @@ object SparkActions {
       * @param labels - list of labels to snapshot
       * @return
       */
-    def cacheAsPartitionedParquet(partitions: Seq[String], repartition: Boolean = true)(labels: String*): SparkDataFlow = {
+    def cacheAsPartitionedParquet(partitions: Option[Either[Seq[String], Int]], repartition: Boolean = true)(labels: String*): SparkDataFlow = {
       if (labels.isEmpty) throw new DataFlowException(s"At least one label must be specified for cacheAsParquet")
 
       labels.foldLeft(sparkDataFlow) { (flow, label) => SparkInterceptors.addCacheAsParquet(flow, label, partitions, repartition) }
@@ -655,6 +666,15 @@ object SparkActions {
       * @return
       */
     def inPlaceTransform(label: String)(post: Dataset[_] => Dataset[_]): SparkDataFlow = SparkInterceptors.addPostTransform(sparkDataFlow, label)(post)
+
+  }
+
+  private[dataflow] implicit class SparkDataFlowInternal(sparkDataFlow: SparkDataFlow) extends Logging {
+
+    def writeRepartitionedPartitionedParquet(basePath: String, partitions: Option[Either[Seq[String], Int]], repartition: Boolean)(label: String): SparkDataFlow = {
+      val (df, dfw) = applyRepartitionAndPartitionBy(partitions, repartition)
+      sparkDataFlow.write(label, df, dfw andThen applyWriteParquet(new Path(basePath, label).toString))
+    }
 
   }
 
@@ -689,12 +709,22 @@ object SparkActionHelpers {
     ds => if (repartition && partitionCols.nonEmpty) ds.repartition(partitionCols.map(ds(_)): _*) else ds
   }
 
+  def applyRepartition(repartition: Int): Dataset[_] => Dataset[_] = {
+    ds => ds.repartition(repartition)
+  }
+
   def applyFileReduce(numFiles: Option[Int]): Dataset[_] => Dataset[_] = {
     ds => numFiles.map(ds.repartition).getOrElse(ds)
   }
 
   def applyPartitionBy(partitionCols: Seq[String]): DataFrameWriter[_] => DataFrameWriter[_] = {
     dfw => if (partitionCols.nonEmpty) dfw.partitionBy(partitionCols: _*) else dfw
+  }
+
+  def applyRepartitionAndPartitionBy(partitions: Option[Either[Seq[String], Int]], repartition: Boolean): (Dataset[_] => Dataset[_], DataFrameWriter[_] => DataFrameWriter[_]) = partitions match {
+    case None => (e => e, w => w)
+    case Some(Left(p)) => (applyRepartition(p, repartition), applyPartitionBy(p))
+    case Some(Right(p)) => (applyRepartition(p), w => w)
   }
 
   def applyMode(mode: SaveMode): DataFrameWriter[_] => DataFrameWriter[_] = dfw => dfw.mode(mode)

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkFlowContext.scala
@@ -15,7 +15,7 @@ import org.apache.spark.sql.SparkSession
   */
 case class SparkFlowContext(spark: SparkSession) extends FlowContext {
 
-  private val uriToUse = spark.conf.get("spark.waimak.fs.defaultFS", spark.sparkContext.hadoopConfiguration.get("fs.defaultFS"))
+  private val uriToUse = getString("spark.waimak.fs.defaultFS", spark.sparkContext.hadoopConfiguration.get("fs.defaultFS"))
 
   lazy val fileSystem: FileSystem = FileSystem.get(new URI(uriToUse), spark.sparkContext.hadoopConfiguration)
 
@@ -24,4 +24,6 @@ case class SparkFlowContext(spark: SparkSession) extends FlowContext {
   override def reportActionStarted(action: DataFlowAction): Unit = spark.sparkContext.setJobGroup(action.guid, action.description)
 
   override def reportActionFinished(action: DataFlowAction): Unit = spark.sparkContext.clearJobGroup()
+
+  override def getOption(key: String): Option[String] = spark.conf.getOption(key)
 }

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestParquetDataCommitter.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestParquetDataCommitter.scala
@@ -128,9 +128,9 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
         initSnapshotFolders(new File(baseDest, "label_ok"), Seq("snap=2000"))
 
         val res = committer.validate(flow, "f1", Seq(
-          CommitEntry("label_fail_1", "f1", Seq.empty, repartition = false, cache = true)
-          , CommitEntry("label_fail_2", "f1", Seq.empty, repartition = false, cache = true)
-          , CommitEntry("label_ok", "f1", Seq.empty, repartition = false, cache = true))
+          CommitEntry("label_fail_1", "f1", None, repartition = false, cache = true)
+          , CommitEntry("label_fail_2", "f1", None, repartition = false, cache = true)
+          , CommitEntry("label_ok", "f1", None, repartition = false, cache = true))
         )
         res shouldBe a[Failure[_]]
         res.failed.get.getMessage should be("ParquetDataCommitter [f1], snapshot folder [snap=2001] is already present for labels: [label_fail_1, label_fail_2]")
@@ -143,14 +143,14 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
         val baseDest = testingBaseDir + "/dest"
         val committer = ParquetDataCommitter(baseDest)
         val flow: SparkDataFlow = Waimak.sparkFlow(sparkSession, tmpDir.toString)
-        committer.validate(flow, "fff", Seq(CommitEntry("label_1", "fff", Seq.empty, repartition = false, cache = true))) should be(Success())
+        committer.validate(flow, "fff", Seq(CommitEntry("label_1", "fff", None, repartition = false, cache = true))) should be(Success())
       }
 
       it("with snapshot and no cleanup") {
         val baseDest = testingBaseDir + "/dest"
         val committer = ParquetDataCommitter(baseDest).withSnapshotFolder("ts=777777")
         val flow: SparkDataFlow = Waimak.sparkFlow(sparkSession, tmpDir.toString)
-        committer.validate(flow, "fff", Seq(CommitEntry("label_1", "fff", Seq.empty, repartition = false, cache = true))) should be(Success())
+        committer.validate(flow, "fff", Seq(CommitEntry("label_1", "fff", None, repartition = false, cache = true))) should be(Success())
       }
 
       it("multiple labels, no clash of the snapshot folders of committed labels") {
@@ -166,10 +166,10 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
         initSnapshotFolders(new File(baseDest, "label_3"), Seq("snap=2000"))
 
         val res = committer.validate(flow, "f1", Seq(
-          CommitEntry("label_1", "f1", Seq.empty, repartition = false, cache = true)
-          , CommitEntry("label_2", "f1", Seq.empty, repartition = false, cache = true)
-          , CommitEntry("label_3", "f1", Seq.empty, repartition = false, cache = true)
-          , CommitEntry("label_no_init", "f1", Seq.empty, repartition = false, cache = true))
+          CommitEntry("label_1", "f1", None, repartition = false, cache = true)
+          , CommitEntry("label_2", "f1", None, repartition = false, cache = true)
+          , CommitEntry("label_3", "f1", None, repartition = false, cache = true)
+          , CommitEntry("label_no_init", "f1", None, repartition = false, cache = true))
         )
         res should be(Success())
       }
@@ -265,7 +265,7 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
         val flow = Waimak.sparkFlow(spark, s"$baseDest/tmp")
           .openCSV(basePath)("csv_1")
           .alias("csv_1", "items")
-          .commit("commit", cacheLabels = false)("items")
+          .commit("commit")("items")
           .push("commit")(ParquetDataCommitter(baseDest).withSnapshotFolder("generated_timestamp=20180509094500"))
 
         val (ex, _) = Waimak.sparkExecutor().execute(flow)
@@ -286,7 +286,7 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
         val flow = Waimak.sparkFlow(spark, s"$baseDest/tmp")
           .openCSV(basePath)("csv_1")
           .alias("csv_1", "items")
-          .commit("commit", cacheLabels = false)("items")
+          .commit("commit")("items")
           .push("commit")(ParquetDataCommitter(baseDest).withSnapshotFolder("generated_timestamp=20180509094500"))
           .alias("items", "items_aliased")
 
@@ -309,8 +309,8 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
         val flow = Waimak.sparkFlow(spark, s"$baseDest1/tmp")
           .openCSV(basePath)("csv_1")
           .alias("csv_1", "items")
-          .commit("commit1", cacheLabels = false)("items")
-          .commit("commit2", cacheLabels = false)("items")
+          .commit("commit1")("items")
+          .commit("commit2")("items")
           .push("commit1")(ParquetDataCommitter(baseDest1).withSnapshotFolder("generated_timestamp=20180509094500"))
           .push("commit2")(ParquetDataCommitter(baseDest2).withSnapshotFolder("generated_timestamp=20180509094500"))
 


### PR DESCRIPTION
# Description

This change introduces the option of staging a commit with a numeric repartition value.

Also introduces a get conf mechanism on the flow context, and moves the cache commit option to a global conf.

Fixes #53 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests

# Note
The wiki pages for commit actions and parameters will need to be updated