### PR TITLE
Consider average row size for compaction and fix recompactAll behaviour

### DIFF
--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
@@ -92,19 +92,18 @@ trait AuditTable {
     * @param trashMaxAge             Maximum age of old region files kept in the .Trash folder
     *                                after a compaction has happened.
     * @param smallRegionRowThreshold the row number threshold to use for determining small regions to be compacted.
-    *                                Default is 50000000
-    * @param hotCellsPerPartition    approximate maximum number of cells (numRows * numColumns) to be in each hot partition file.
-    *                                Adjust this to control output file size. Default is 1000000
-    * @param coldCellsPerPartition   approximate maximum number of cells (numRows * numColumns) to be in each cold partition file.
-    *                                Adjust this to control output file size. Default is 2500000
+    * @param hotBytesPerPartition    approximate maximum number of bytes to be in each hot partition file.
+    *                                Adjust this to control output file size.
+    * @param coldBytesPerPartition   approximate maximum number of bytes to be in each cold partition file.
+    *                                Adjust this to control output file size.
     * @param recompactAll            Whether to recompact all regions regardless of size (i.e. ignore smallRegionRowThreshold)
     * @return new state of the AuditTable
     */
   def compact(compactTS: Timestamp
               , trashMaxAge: Duration
-              , smallRegionRowThreshold: Int = 50000000
-              , hotCellsPerPartition: Int = 1000000
-              , coldCellsPerPartition: Int = 2500000
+              , smallRegionRowThreshold: Long
+              , hotBytesPerPartition: Long
+              , coldBytesPerPartition: Long
               , recompactAll: Boolean = false): Try[AuditTable]
 
   /**

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
@@ -8,7 +8,6 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql._
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.StructType
 
 import scala.util.{Failure, Success, Try}
 
@@ -90,22 +89,22 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     *                                after a compaction has happened.
     * @param smallRegionRowThreshold the row number threshold to use for determining small regions to be compacted.
     *                                Default is 50000000
-    * @param hotCellsPerPartition    approximate maximum number of cells (numRows * numColumns) to be in each hot partition file.
+    * @param hotBytesPerPartition    approximate maximum number of bytes to be in each hot partition file.
     *                                Adjust this to control output file size. Default is 1000000
-    * @param coldCellsPerPartition   approximate maximum number of cells (numRows * numColumns) to be in each cold partition file.
+    * @param coldBytesPerPartition   approximate maximum number of bytes to be in each cold partition file.
     *                                Adjust this to control output file size. Default is 2500000
     * @param recompactAll            Whether to recompact all regions regardless of size (i.e. ignore smallRegionRowThreshold)
     * @return new state of the AuditTable
     */
   override def compact(compactTS: Timestamp
                        , trashMaxAge: Duration
-                       , smallRegionRowThreshold: Int
-                       , hotCellsPerPartition: Int
-                       , coldCellsPerPartition: Int
+                       , smallRegionRowThreshold: Long
+                       , hotBytesPerPartition: Long
+                       , coldBytesPerPartition: Long
                        , recompactAll: Boolean): Try[AuditTable] = {
     val res: Try[AuditTableFile] = Try(markToUpdate())
-      .flatMap(_ => commitHotToCold(compactTS, hotCellsPerPartition))
-      .flatMap(_.compactCold(compactTS, smallRegionRowThreshold, coldCellsPerPartition, recompactAll))
+      .flatMap(_ => commitHotToCold(compactTS, hotBytesPerPartition))
+      .flatMap(_.compactCold(compactTS, smallRegionRowThreshold, coldBytesPerPartition, recompactAll))
       .map { f =>
         f.storageOps.purgeTrash(f.tableName, compactTS, trashMaxAge)
         f
@@ -147,13 +146,13 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     * Compacts all hot regions into one cold.
     *
     * @param compactTS         the compaction timestamp
-    * @param cellsPerPartition approximate maximum number of cells (numRows * numColumns) to be in each partition file.
+    * @param bytesPerPartition approximate maximum number of bytes to be in each partition file.
     *                          Adjust this to control output file size,
     * @return
     */
-  protected def commitHotToCold(compactTS: Timestamp, cellsPerPartition: Int): Try[AuditTableFile] = {
+  protected def commitHotToCold(compactTS: Timestamp, bytesPerPartition: Long): Try[AuditTableFile] = {
     val hotRegions = regions.filter(r => !r.is_deprecated && r.store_type == HOT_PARTITION)
-    compactRegions(hotPath, hotRegions, compactTS, cellsPerPartition)
+    compactRegions(hotPath, hotRegions, compactTS, bytesPerPartition)
   }
 
   /**
@@ -161,25 +160,25 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     *
     * @param compactTS               the compaction timestamp
     * @param smallRegionRowThreshold the row number threshold to use for determinining small regions to be compacted
-    * @param cellsPerPartition       approximate maximum number of cells (numRows * numColumns) to be in each partition file.
+    * @param bytesPerPartition       approximate maximum number of bytes to be in each partition file.
     *                                Adjust this to control output file size.
     * @return
     */
   protected def compactCold(compactTS: Timestamp
-                            , smallRegionRowThreshold: Int
-                            , cellsPerPartition: Int
+                            , smallRegionRowThreshold: Long
+                            , bytesPerPartition: Long
                             , recompactAll: Boolean): Try[AuditTableFile] = {
     val smallerRegions =
       if (recompactAll) regions
       else regions.filter(r => r.store_type == COLD_PARTITION && r.count < smallRegionRowThreshold)
     // No use compacting a single small region into itself
-    compactRegions(coldPath, if (smallerRegions.length < 2 && !recompactAll) Seq.empty else smallerRegions, compactTS, cellsPerPartition)
+    compactRegions(coldPath, if (smallerRegions.length < 2 && !recompactAll) Seq.empty else smallerRegions, compactTS, bytesPerPartition)
   }
 
   protected def compactRegions(typePath: Path
                                , toCompact: Seq[AuditTableRegionInfo]
                                , compactTS: Timestamp
-                               , cellsPerPartition: Int): Try[AuditTableFile] = {
+                               , bytesPerPartition: Long): Try[AuditTableFile] = {
     Try {
       val res = if (toCompact.isEmpty) new AuditTableFile(this.tableInfo, this.regions, this.storageOps, this.baseFolder, this.newRegionID)
       else {
@@ -194,8 +193,8 @@ class AuditTableFile(val tableInfo: AuditTableInfo
           //Clear current region info to prevent corruption on failure
           clearTableRegionCache(this)
           val currentNumPartitions = rows.rdd.getNumPartitions
-          val newNumPartitions = calculateNumPartitions(rows.schema, toCompact.map(_.count).sum, cellsPerPartition)
           val rowsToCompact = rows.filter(rows(STORE_REGION_COLUMN).isin(ids: _*)).drop(STORE_REGION_COLUMN)
+          val newNumPartitions = calculateNumPartitions(rowsToCompact, toCompact.map(_.count).sum, bytesPerPartition)
           val rowsToCompactRepartitioned = if (newNumPartitions > currentNumPartitions) {
             rowsToCompact.repartition(newNumPartitions)
           } else rowsToCompact.coalesce(newNumPartitions)
@@ -213,10 +212,10 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     }
   }
 
-  protected def calculateNumPartitions(schema: StructType, numRows: Long, cellsPerPartition: Long): Int = {
-    val cellsPerRow = schema.size
-    val rowsPerPartition = cellsPerPartition / cellsPerRow
-    (numRows / rowsPerPartition).toInt + 1
+  protected def calculateNumPartitions(ds: Dataset[_], numRows: Long, bytesPerPartition: Long): Int = {
+    import org.apache.spark.util.SizeEstimator
+    val averageBytesPerRow = ds.toDF().rdd.map(SizeEstimator.estimate).mean()
+    ((numRows * averageBytesPerRow) / bytesPerPartition).toInt + 1
   }
 
   protected def calcRegionStats(ds: Dataset[_]): (Long, Timestamp) = {

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
@@ -129,7 +129,7 @@ object StorageActions extends Logging {
         val (existingTables, missingTables) = Storage.openFileTables(sparkDataFlow.flowContext.spark, basePath, tableNames, includeHot)
 
         if (missingTables.nonEmpty && metadataRetrieval.isEmpty) {
-          throw StorageException(s"The following tables were not found in the storage layer and could not be created as no metadata function was defined")
+          throw StorageException(s"The following tables were not found in the storage layer and could not be created as no metadata function was defined: ${missingTables.mkString(",")}")
         }
 
         val createdTables = missingTables.map { tableName =>

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
@@ -22,24 +22,24 @@ object StorageActions extends Logging {
     * after a compaction has happened.
     */
   val TRASH_MAX_AGE_MS: String = s"$storageParamPrefix.trashMaxAgeMs"
-  val TRASH_MAX_AGE_MS_DEFAULT: Int = 86400000
+  val TRASH_MAX_AGE_MS_DEFAULT: Long = 86400000
   /**
     * The row number threshold to use for determining small regions to be compacted.
     */
   val SMALL_REGION_ROW_THRESHOLD: String = s"$storageParamPrefix.smallRegionRowThreshold"
-  val SMALL_REGION_ROW_THRESHOLD_DEFAULT = 50000000
+  val SMALL_REGION_ROW_THRESHOLD_DEFAULT: Long = 50000000
   /**
-    * Approximate maximum number of cells (numRows * numColumns) to be in each hot partition file.
+    * Approximate maximum number of bytes to be in each hot partition file.
     * Adjust this to control output file size
     */
-  val HOT_CELLS_PER_PARTITION = s"$storageParamPrefix.hotCellsPerPartition"
-  val HOT_CELLS_PER_PARTITION_DEFAULT = 1000000
+  val HOT_BYTES_PER_PARTITION = s"$storageParamPrefix.hotBytesPerPartition"
+  val HOT_BYTES_PER_PARTITION_DEFAULT: Long = 100000000
   /**
-    * Approximate maximum number of cells (numRows * numColumns) to be in each cold partition file.
+    * Approximate maximum number of bytes to be in each cold partition file.
     * Adjust this to control output file size
     */
-  val COLD_CELLS_PER_PARTITION = s"$storageParamPrefix.coldCellsPerPartition"
-  val COLD_CELLS_PER_PARTITION_DEFAULT = 2500000
+  val COLD_BYTES_PER_PARTITION = s"$storageParamPrefix.coldBytesPerPartition"
+  val COLD_BYTES_PER_PARTITION_DEFAULT: Long = 250000000
   /**
     * Whether to recompact all regions regardless of size (i.e. ignore [[SMALL_REGION_ROW_THRESHOLD]])
     */
@@ -127,14 +127,14 @@ object StorageActions extends Logging {
           case Success((t, c)) if doCompaction(t.regions, c, appendDateTime) =>
             logInfo(s"Compaction has been triggered on table [$labelName], with compaction timestamp [$appendTimestamp].")
             val trashMaxAge = Duration.ofMillis(sparkConf.getLong(TRASH_MAX_AGE_MS, TRASH_MAX_AGE_MS_DEFAULT))
-            val smallRegionRowThreshold = sparkConf.getInt(SMALL_REGION_ROW_THRESHOLD, SMALL_REGION_ROW_THRESHOLD_DEFAULT)
-            val hotCellsPerPartition = sparkConf.getInt(HOT_CELLS_PER_PARTITION, HOT_CELLS_PER_PARTITION_DEFAULT)
-            val coldCellsPerPartition = sparkConf.getInt(COLD_CELLS_PER_PARTITION, COLD_CELLS_PER_PARTITION_DEFAULT)
+            val smallRegionRowThreshold = sparkConf.getLong(SMALL_REGION_ROW_THRESHOLD, SMALL_REGION_ROW_THRESHOLD_DEFAULT)
+            val hotBytesPerPartition = sparkConf.getLong(HOT_BYTES_PER_PARTITION, HOT_BYTES_PER_PARTITION_DEFAULT)
+            val coldBytesPerPartition = sparkConf.getLong(COLD_BYTES_PER_PARTITION, COLD_BYTES_PER_PARTITION_DEFAULT)
             val recompactAll = sparkConf.getBoolean(RECOMPACT_ALL, RECOMPACT_ALL_DEFAULT)
             t.compact(compactTS = appendTimestamp
               , trashMaxAge = trashMaxAge
-              , coldCellsPerPartition = coldCellsPerPartition
-              , hotCellsPerPartition = hotCellsPerPartition
+              , coldBytesPerPartition = coldBytesPerPartition
+              , hotBytesPerPartition = hotBytesPerPartition
               , smallRegionRowThreshold = smallRegionRowThreshold
               , recompactAll = recompactAll) match {
               case Success(_) => Seq.empty

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -112,14 +112,12 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       val executor = Waimak.sparkExecutor()
 
-      val auditTable = Storage.createFileTable(spark, new Path(testingBaseDirName), AuditTableInfo("t_record", Seq("id"), Map.empty))
-        .get.asInstanceOf[AuditTableFile]
-
       val laZts = zdt1.withZoneSameLocal(ZoneId.of("America/Los_Angeles"))
 
       val writeFlow = Waimak.sparkFlow(spark)
         .addInput("t_record", Some(records.toDS()))
-        .writeToStorage("t_record", auditTable, "lastUpdated", laZts)
+        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty)))("t_record")
+        .writeToStorage("t_record", "lastUpdated", laZts)
 
       executor.execute(writeFlow)
 
@@ -130,6 +128,7 @@ class TestStorageActions extends SparkAndTmpDirSpec {
       res1._2.inputs.get[Dataset[_]]("t_record").sort("lastUpdated").as[TRecord].collect() should be(records)
 
       // Should be a single cold region
+      val auditTable = res1._2.inputs.getAllOfType[AuditTableFile].head
       val regions = AuditTableFile.inferRegionsWithStats(spark, auditTable.storageOps, auditTable.baseFolder, Seq("t_record"))
       regions.map(_.store_type) should be(Seq("cold"))
 

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -69,7 +69,7 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
     }
 
-    it("should write with commit read everything") {
+    it("should write with compaction in window, and read everything") {
       val spark = sparkSession
       import spark.implicits._
       val records = Seq(
@@ -103,6 +103,43 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       regions.map(_.created_on) should be(Seq(Timestamp.valueOf("2018-05-08 17:55:12")))
     }
+
+    it("should write with force recompaction, and read everything") {
+      val spark = sparkSession
+      spark.conf.set(RECOMPACT_ALL, true)
+      import spark.implicits._
+      val records = Seq(
+        TRecord(1, "a", ts1)
+        , TRecord(2, "b", ts2)
+        , TRecord(1, "c", ts3)
+      )
+
+      val executor = Waimak.sparkExecutor()
+
+      val auditTable = Storage.createFileTable(spark, new Path(testingBaseDirName), AuditTableInfo("t_record", Seq("id"), Map.empty))
+        .get.asInstanceOf[AuditTableFile]
+
+      val laZts = zdt1.withZoneSameLocal(ZoneId.of("America/Los_Angeles"))
+
+      val writeFlow = Waimak.sparkFlow(spark)
+        .addInput("t_record", Some(records.toDS()))
+        .writeToStorage("t_record", auditTable, "lastUpdated", laZts)
+
+      executor.execute(writeFlow)
+
+      val readEverythingFlow = Waimak.sparkFlow(spark)
+        .loadFromStorage(testingBaseDirName)("t_record")
+
+      val res1 = executor.execute(readEverythingFlow)
+      res1._2.inputs.get[Dataset[_]]("t_record").sort("lastUpdated").as[TRecord].collect() should be(records)
+
+      // Should be a single cold region
+      val regions = AuditTableFile.inferRegionsWithStats(spark, auditTable.storageOps, auditTable.baseFolder, Seq("t_record"))
+      regions.map(_.store_type) should be(Seq("cold"))
+
+      regions.map(_.created_on) should be(Seq(Timestamp.valueOf("2018-05-08 17:55:12")))
+    }
+
   }
 
   describe("runSingleCompactionDuringWindow") {

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -3,8 +3,8 @@ package com.coxautodata.waimak.storage
 import java.sql.Timestamp
 import java.time.{ZoneId, ZoneOffset}
 
-import com.coxautodata.waimak.dataflow.Waimak
 import com.coxautodata.waimak.dataflow.spark.SparkAndTmpDirSpec
+import com.coxautodata.waimak.dataflow.{DataFlowException, Waimak}
 import com.coxautodata.waimak.storage.AuditTableFile.lowTimestamp
 import com.coxautodata.waimak.storage.StorageActions._
 import org.apache.spark.sql.Dataset
@@ -133,6 +133,20 @@ class TestStorageActions extends SparkAndTmpDirSpec {
       regions.map(_.store_type) should be(Seq("cold"))
 
       regions.map(_.created_on) should be(Seq(Timestamp.valueOf("2018-05-08 17:55:12")))
+    }
+
+    it("should fail if a table was not found in the storage layer") {
+      val spark = sparkSession
+
+      val executor = Waimak.sparkExecutor()
+
+      val writeFlow = Waimak.sparkFlow(spark)
+        .getOrCreateAuditTable(testingBaseDirName, None)("t_record")
+
+      intercept[DataFlowException](
+        executor.execute(writeFlow)
+      ).cause.getMessage should be("The following tables were not found in the storage layer and could not be created as no metadata function was defined: t_record")
+
     }
 
   }


### PR DESCRIPTION
# Description

This PR introduces a generic way of calculating the number of partitions to use when generating parquet files during a compaction in the storage layer.

There are two implementations to use:

- A function that now takes into account the average `Row` size of rows in a Dataset and splits on a maximum bytes per partition size. By default, the dataset is sampled, the average row size calculated and extrapolated. Note: This approach only calculates the size of the Row objects in the JVM, and does not take into account the compressed size of serialized Parquet objects when they are written, however the size should be correlated.

- The existing implementation of calculating the total number of cells per partition.

Also fixes/changes the behaviour of the `recompactAll` flag to now force a recompaction regardless of whether we are in a compaction window or now.

Fixes #32 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests, should test on data during release branch