### PR TITLE
Rework storage API

### DIFF
--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
@@ -1,14 +1,15 @@
 package com.coxautodata.waimak.rdbm.ingestion
 
 import java.sql.Timestamp
-import java.time.{Duration, ZonedDateTime}
+import java.time.ZonedDateTime
+import java.util.UUID
 
 import com.coxautodata.waimak.configuration.CaseClassConfigParser
 import com.coxautodata.waimak.dataflow.spark.{SimpleAction, SparkDataFlow}
 import com.coxautodata.waimak.dataflow.{ActionResult, DataFlowEntities}
 import com.coxautodata.waimak.log.Logging
 import com.coxautodata.waimak.storage.StorageActions._
-import com.coxautodata.waimak.storage.{AuditTable, AuditTableRegionInfo, Storage}
+import com.coxautodata.waimak.storage.{AuditTable, AuditTableInfo, AuditTableRegionInfo, Storage}
 import org.apache.hadoop.fs.Path
 
 /**
@@ -49,45 +50,22 @@ object RDBMIngestionActions {
                                  , forceFullLoad: Boolean = false
                                  , doCompaction: (Seq[AuditTableRegionInfo], Long, ZonedDateTime) => Boolean = (_, _, _) => false)(tables: String*): SparkDataFlow = {
 
-      val basePath = new Path(storageBasePath)
+      def metadataFunction(tableName: String): AuditTableInfo = {
+        val tableConfig = tableConfigs(tableName)
+        rdbmExtractor.getTableMetadata(dbSchema, tableName, tableConfig.pkCols, tableConfig.lastUpdatedColumn).get
+      }
 
-      val (existingTables, newTables) = Storage.openFileTables(sparkDataFlow.flowContext.spark, basePath, tables.toSeq)
+      val randomPrefix = UUID.randomUUID().toString
 
-      val newTableMetadata = newTables.map(t => {
-        val tableConfig = tableConfigs(t)
-        (t,
-          rdbmExtractor.getTableMetadata(dbSchema, t, tableConfig.pkCols, tableConfig.lastUpdatedColumn)
-            .map(_.copy(table_name = t)))
-      }).toMap
+      val openFlow = sparkDataFlow
+        .getOrCreateAuditTable(storageBasePath, Some(metadataFunction), Some(randomPrefix), true)(tables: _*)
 
-      handleTableErrors(newTableMetadata, "Unable to fetch metadata")
+      tables.foldLeft(openFlow) { (flow, tableName) =>
+        flow
+          .extractFromRDBM(rdbmExtractor, lastUpdatedOffset, tableName, randomPrefix, tableConfigs(tableName).maxRowsPerPartition, forceFullLoad)
+          .writeToStorage(tableName, rdbmExtractor.rdbmRecordLastUpdatedColumn, extractDateTime, doCompaction, randomPrefix)
+      }
 
-      val createdTables = newTableMetadata.values.map(_.get).map(tableInfo => {
-        logInfo(s"Creating table ${tableInfo.table_name} with metadata $tableInfo")
-        tableInfo.table_name -> Storage.createFileTable(sparkDataFlow.flowContext.spark, basePath, tableInfo)
-      }).toMap
-
-      handleTableErrors(createdTables, "Unable to perform create")
-
-      handleTableErrors(existingTables, "Unable to perform read")
-
-      val allTables = existingTables.values.map(_.get) ++ createdTables.values.map(_.get)
-
-      allTables.foldLeft(sparkDataFlow)((flow, table) => {
-        val lastUpdatedToUseOnRead = table.getLatestTimestamp()
-          .map(_.toLocalDateTime.minusSeconds(lastUpdatedOffset))
-          .map(Timestamp.valueOf)
-
-        logInfo(s"Extracting table ${table.tableName} with last updated $lastUpdatedToUseOnRead and metadata ${table.meta}")
-
-        flow.extractFromRDBM(rdbmExtractor
-          , table.meta
-          , lastUpdatedToUseOnRead
-          , table.tableName
-          , tableConfigs(table.tableName).maxRowsPerPartition
-          , forceFullLoad)
-          .writeToStorage(table.tableName, table, rdbmExtractor.rdbmRecordLastUpdatedColumn, extractDateTime, doCompaction)
-      })
     }
 
     /**
@@ -102,16 +80,28 @@ object RDBMIngestionActions {
       * @return A new SparkDataFlow with the extraction actions added
       */
     def extractFromRDBM(rdbmExtractor: RDBMExtractor
-                        , tableMetadata: Map[String, String]
-                        , lastUpdated: Option[Timestamp]
+                        , lastUpdatedOffset: Long
                         , label: String
+                        , auditTableLabelPrefix: String
                         , maxRowsPerPartition: Option[Int] = None
                         , forceFullLoad: Boolean = false): SparkDataFlow = {
 
-      val run: DataFlowEntities => ActionResult =
-        _ => Seq(Some(rdbmExtractor.getTableDataset(tableMetadata, lastUpdated, maxRowsPerPartition, forceFullLoad)))
+      val auditTableLabel = s"${auditTableLabelPrefix}_$label"
 
-      sparkDataFlow.addAction(new SimpleAction(List.empty, List(label), run))
+      val run: DataFlowEntities => ActionResult = {
+        m =>
+          val auditTable = m.get[AuditTable](auditTableLabel)
+          val lastUpdated = auditTable.getLatestTimestamp()
+            .map(_.toLocalDateTime.minusSeconds(lastUpdatedOffset))
+            .map(Timestamp.valueOf)
+
+          logInfo(s"Extracting table $label with last updated $lastUpdated and metadata ${auditTable.meta}")
+
+
+          Seq(Some(rdbmExtractor.getTableDataset(auditTable.meta, lastUpdated, maxRowsPerPartition, forceFullLoad)))
+      }
+
+      sparkDataFlow.addAction(new SimpleAction(List(auditTableLabel), List(label), run, "extractFromRDBM"))
     }
 
 
@@ -129,24 +119,25 @@ object RDBMIngestionActions {
       * @return A new SparkDataFlow with the read actions added
       */
     def snapshotTemporalTablesFromStorage(storageBasePath: String, snapshotTimestamp: Timestamp)(tables: String*): SparkDataFlow = {
-      val basePath = new Path(storageBasePath)
 
-      val (existingTables, newTables) = Storage.openFileTables(sparkDataFlow.flowContext.spark, basePath, tables.toSeq)
-      if (newTables.nonEmpty) throw new RuntimeException(s"Tables do not exist: $newTables")
-
-      handleTableErrors(existingTables, "Unable to perform read")
-
-
-      def run(table: AuditTable): DataFlowEntities => ActionResult = _ => {
+      def run(auditTableLabel: String): DataFlowEntities => ActionResult = m => {
+        val table = m.get[AuditTable](auditTableLabel)
         val temporalTableMetadata = CaseClassConfigParser.fromMap[SQLServerTemporalTableMetadata](table.meta)
         if (!temporalTableMetadata.isTemporal) Seq(table.snapshot(snapshotTimestamp))
         else Seq(table.allBetween(None, Some(snapshotTimestamp))
           .map(ds => RDBMIngestionUtils.snapshotTemporalTableDataset(ds, snapshotTimestamp, temporalTableMetadata)))
       }
 
-      existingTables.values.map(_.get).foldLeft(sparkDataFlow)((flow, table) => {
-        flow.addAction(new SimpleAction(List.empty, List(table.tableName), run(table)))
+      val randomPrefix = UUID.randomUUID().toString
+
+      val openFlow = sparkDataFlow
+        .getOrCreateAuditTable(storageBasePath, None, Some(randomPrefix), true)(tables: _*)
+
+      tables.foldLeft(openFlow)((flow, table) => {
+        val auditTableLabel = s"${randomPrefix}_$table"
+        flow.addAction(new SimpleAction(List(auditTableLabel), List(table), run(auditTableLabel), "snapshotTemporalTablesFromStorage"))
       })
+
     }
   }
 

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -35,12 +35,10 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       val executor = Waimak.sparkExecutor()
 
-      val auditTable = Storage.createFileTable(spark, new Path(testingBaseDirName), AuditTableInfo("t_record", Seq("id"), Map.empty))
-        .get
-
       val writeFlow = Waimak.sparkFlow(spark)
         .addInput("t_record", Some(records.toDS()))
-        .writeToStorage("t_record", auditTable, "lastUpdated", zdt1)
+        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty)))("t_record")
+        .writeToStorage("t_record", "lastUpdated", zdt1)
 
       executor.execute(writeFlow)
 
@@ -80,14 +78,12 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       val executor = Waimak.sparkExecutor()
 
-      val auditTable = Storage.createFileTable(spark, new Path(testingBaseDirName), AuditTableInfo("t_record", Seq("id"), Map.empty))
-        .get.asInstanceOf[AuditTableFile]
-
       val laZts = zdt1.withZoneSameLocal(ZoneId.of("America/Los_Angeles"))
 
       val writeFlow = Waimak.sparkFlow(spark)
         .addInput("t_record", Some(records.toDS()))
-        .writeToStorage("t_record", auditTable, "lastUpdated", laZts, runSingleCompactionDuringWindow(10, 11))
+        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty)))("t_record")
+        .writeToStorage("t_record", "lastUpdated", laZts, runSingleCompactionDuringWindow(10, 11))
 
       executor.execute(writeFlow)
 
@@ -98,6 +94,7 @@ class TestStorageActions extends SparkAndTmpDirSpec {
       res1._2.inputs.get[Dataset[_]]("t_record").sort("lastUpdated").as[TRecord].collect() should be(records)
 
       // Should be a single cold region
+      val auditTable = res1._2.inputs.getAllOfType[AuditTableFile].head
       val regions = AuditTableFile.inferRegionsWithStats(spark, auditTable.storageOps, auditTable.baseFolder, Seq("t_record"))
       regions.map(_.store_type) should be(Seq("cold"))
 

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -7,7 +7,6 @@ import com.coxautodata.waimak.dataflow.Waimak
 import com.coxautodata.waimak.dataflow.spark.SparkAndTmpDirSpec
 import com.coxautodata.waimak.storage.AuditTableFile.lowTimestamp
 import com.coxautodata.waimak.storage.StorageActions._
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.Dataset
 
 /**


### PR DESCRIPTION
# Description

This PR makes several breaking changes to improve storage actions. Audit tables are now entities on the flow, and all audit table reading happens in actions on the flow.

Fixes #51 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests
