### PR TITLE
Feature/optionally remove storage history on compaction

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/filesystem/FSUtils.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/filesystem/FSUtils.scala
@@ -108,11 +108,11 @@ object FSUtils extends Logging {
     */
   def moveOverwriteFolder(fs: FileSystem, toMove: Path, toPath: Path): Boolean = {
     if (!fs.exists(toPath.getParent)) {
-      logInfo("Create parent folder " + toPath.getParent)
+      logDebug("Create parent folder " + toPath.getParent)
       fs.mkdirs(toPath.getParent)
     }
     if (fs.exists(toMove)) {
-      logInfo(s"Removing ${toPath.toString} in order to replace.")
+      logDebug(s"Removing ${toPath.toString} in order to replace.")
       fs.delete(toPath, true)
     }
     val committed = fs.rename(toMove, toPath)

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/filesystem/FSUtils.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/filesystem/FSUtils.scala
@@ -116,7 +116,7 @@ object FSUtils extends Logging {
       fs.delete(toPath, true)
     }
     val committed = fs.rename(toMove, toPath)
-    logInfo(s"${committed} move of [${toMove.toString}] into [${toPath}]")
+    logDebug(s"Move of [${toMove.toString}] into [$toPath] was successful: $committed")
     committed
   }
 
@@ -193,7 +193,7 @@ object FSUtils extends Logging {
         val from = new Path(fromPath, f)
         val to = new Path(toPath, f)
         val res = fs.rename(from, to)
-        logInfo(s"${res} move of [${from.toString}] into [${to}]")
+        logInfo(s"Move of [${from.toString}] into [${to}] was successful: $res")
         res
       }.fold(true)((r, e) => r && e)
     } else false

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
@@ -68,14 +68,14 @@ class PostgresExtractor(override val sparkSession: SparkSession
                                 , tableName: String
                                 , primaryKeys: Option[Seq[String]]
                                 , lastUpdatedColumn: Option[String]
-                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
+                                , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo] = {
     ((primaryKeys, getTablePKs(dbSchemaName, transformTableNameForRead(tableName))) match {
       case (Some(userPKs), Some(pksFromDB)) if userPKs.sorted != pksFromDB.sorted =>
         Failure(IncorrectUserPKException(userPKs, pksFromDB))
       case (Some(userPKs), None) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
       case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
-    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory))
+    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn)))
   }
 
 

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
@@ -67,14 +67,15 @@ class PostgresExtractor(override val sparkSession: SparkSession
   override def getTableMetadata(dbSchemaName: String
                                 , tableName: String
                                 , primaryKeys: Option[Seq[String]]
-                                , lastUpdatedColumn: Option[String]): Try[AuditTableInfo] = {
+                                , lastUpdatedColumn: Option[String]
+                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
     ((primaryKeys, getTablePKs(dbSchemaName, transformTableNameForRead(tableName))) match {
       case (Some(userPKs), Some(pksFromDB)) if userPKs.sorted != pksFromDB.sorted =>
         Failure(IncorrectUserPKException(userPKs, pksFromDB))
       case (Some(userPKs), None) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
       case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
-    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString)))
+    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory))
   }
 
 

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
@@ -60,12 +60,19 @@ trait RDBMExtractor {
 
   /**
     * Tries to get whatever metadata information it can from the database
-    * Uses the optional provided values for pks and lastupdated if it cannot get them from the database.
+    * Uses the optional provided values for pks and lastUpdated if it cannot get them from the database.
     *
-    * @param dbSchemaName      the database schema name
-    * @param tableName         the table name
-    * @param primaryKeys       Optionally, the primary keys for this table
-    * @param lastUpdatedColumn Optionally, the last updated column for this table
+    * @param dbSchemaName              the database schema name
+    * @param tableName                 the table name
+    * @param primaryKeys               Optionally, the primary keys for this table
+    * @param lastUpdatedColumn         Optionally, the last updated column for this table
+    * @param forceRetainStorageHistory Optionally specify whether to retain history for this table in the storage layer.
+    *                                  Setting this to anything other than None will override the default behaviour which is:
+    *                                  - if there is a lastUpdated column found or specified, retain all history for this table
+    *                                  - if there is no lastUpdated column, don't retain history for this table (history is
+    *                                  removed when the table is compacted). The choice of this default behaviour is because,
+    *                                  without a lastUpdatedColumn, the table will be extracted in full every time extraction
+    *                                  is performed, causing the size of the data in storage to grow uncontrollably
     * @return Success[AuditTableInfo] if all required metadata was either found or provided by the user
     *         Failure if required metadata was neither found nor provided by the user
     *         Failure if metadata provided differed from the metadata found in the database
@@ -74,7 +81,19 @@ trait RDBMExtractor {
                        , tableName: String
                        , primaryKeys: Option[Seq[String]]
                        , lastUpdatedColumn: Option[String]
-                       , retainStorageHistory: Boolean): Try[AuditTableInfo]
+                       , forceRetainStorageHistory: Option[Boolean]): Try[AuditTableInfo] = {
+    getTableMetadata(dbSchemaName
+      , tableName
+      , primaryKeys
+      , lastUpdatedColumn
+      , col => forceRetainStorageHistory.getOrElse(col.isDefined))
+  }
+
+  protected def getTableMetadata(dbSchemaName: String
+                                 , tableName: String
+                                 , primaryKeys: Option[Seq[String]]
+                                 , lastUpdatedColumn: Option[String]
+                                 , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo]
 
   def resolveLastUpdatedColumn(tableMetadata: TableExtractionMetadata, sparkSession: SparkSession): Column = {
     import sparkSession.implicits._
@@ -248,7 +267,10 @@ trait RDBMExtractor {
 
 }
 
-case class TableExtractionMetadata(schemaName: String, tableName: String, primaryKeys: Seq[String], lastUpdatedColumn: Option[String] = None) {
+case class TableExtractionMetadata(schemaName: String
+                                   , tableName: String
+                                   , primaryKeys: Seq[String]
+                                   , lastUpdatedColumn: Option[String] = None) {
 
   def qualifiedTableName(escapeKeyword: String => String): String =
     s"${escapeKeyword(schemaName)}.${escapeKeyword(tableName)}"

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
@@ -72,8 +72,9 @@ trait RDBMExtractor {
     */
   def getTableMetadata(dbSchemaName: String
                        , tableName: String
-                       , primaryKeys: Option[Seq[String]] = None
-                       , lastUpdatedColumn: Option[String] = None): Try[AuditTableInfo]
+                       , primaryKeys: Option[Seq[String]]
+                       , lastUpdatedColumn: Option[String]
+                       , retainStorageHistory: Boolean): Try[AuditTableInfo]
 
   def resolveLastUpdatedColumn(tableMetadata: TableExtractionMetadata, sparkSession: SparkSession): Column = {
     import sparkSession.implicits._

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
@@ -49,7 +49,7 @@ object RDBMIngestionActions {
 
       def metadataFunction(tableName: String): AuditTableInfo = {
         val tableConfig = tableConfigs(tableName)
-        rdbmExtractor.getTableMetadata(dbSchema, tableName, tableConfig.pkCols, tableConfig.lastUpdatedColumn).get
+        rdbmExtractor.getTableMetadata(dbSchema, tableName, tableConfig.pkCols, tableConfig.lastUpdatedColumn, tableConfig.retainStorageHistory).get
       }
 
       val randomPrefix = UUID.randomUUID().toString

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionActions.scala
@@ -49,7 +49,7 @@ object RDBMIngestionActions {
 
       def metadataFunction(tableName: String): AuditTableInfo = {
         val tableConfig = tableConfigs(tableName)
-        rdbmExtractor.getTableMetadata(dbSchema, tableName, tableConfig.pkCols, tableConfig.lastUpdatedColumn, tableConfig.retainStorageHistory).get
+        rdbmExtractor.getTableMetadata(dbSchema, tableName, tableConfig.pkCols, tableConfig.lastUpdatedColumn, tableConfig.forceRetainStorageHistory).get
       }
 
       val randomPrefix = UUID.randomUUID().toString

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionUtils.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionUtils.scala
@@ -85,23 +85,29 @@ object RDBMIngestionUtils {
 /**
   * Table configuration used for RDBM extraction
   *
-  * @param tableName           The name of the table
-  * @param pkCols              Optionally, the primary key columns for this table (don't need if the implementation of
-  *                            [[RDBMExtractor]] is capable of getting this information itself)
-  * @param lastUpdatedColumn   Optionally, the last updated column for this table (don't need if the implementation of
-  *                            [[RDBMExtractor]] is capable of getting this information itself)
-  * @param maxRowsPerPartition Optionally, the maximum number of rows to be read per Dataset partition for this table
-  *                            This number will be used to generate predicates to be passed to org.apache.spark.sql.SparkSession.read.jdbc
-  *                            If this is not set, the DataFrame will only have one partition. This could result in memory
-  *                            issues when extracting large tables.
-  *                            Be careful not to create too many partitions in parallel on a large cluster; otherwise
-  *                            Spark might crash your external database systems. You can also control the maximum number
-  *                            of jdbc connections to open by limiting the number of executors for your application.
+  * @param tableName                 The name of the table
+  * @param pkCols                    Optionally, the primary key columns for this table (don't need if the implementation of
+  *                                  [[RDBMExtractor]] is capable of getting this information itself)
+  * @param lastUpdatedColumn         Optionally, the last updated column for this table (don't need if the implementation of
+  *                                  [[RDBMExtractor]] is capable of getting this information itself)
+  * @param maxRowsPerPartition       Optionally, the maximum number of rows to be read per Dataset partition for this table
+  *                                  This number will be used to generate predicates to be passed to org.apache.spark.sql.SparkSession.read.jdbc
+  *                                  If this is not set, the DataFrame will only have one partition. This could result in memory
+  *                                  issues when extracting large tables.
+  *                                  Be careful not to create too many partitions in parallel on a large cluster; otherwise
+  *                                  Spark might crash your external database systems. You can also control the maximum number
+  *                                  of jdbc connections to open by limiting the number of executors for your application.
+  * @param forceRetainStorageHistory Optionally specify whether to retain history for this table in the storage layer.
+  *                                  Setting this to anything other than None will override the default behaviour which is:
+  *                                  - if there is a lastUpdated column (either specified here or found by the [[RDBMExtractor]])
+  *                                  retain all history for this table
+  *                                  - if there is no lastUpdated column, don't retain history for this table (history is
+  *                                  removed when the table is compacted). The choice of this default behaviour is because,
+  *                                  without a lastUpdatedColumn, the table will be extracted in full every time extraction
+  *                                  is performed, causing the size of the data in storage to grow uncontrollably
   */
 case class RDBMExtractionTableConfig(tableName: String
                                      , pkCols: Option[Seq[String]] = None
                                      , lastUpdatedColumn: Option[String] = None
                                      , maxRowsPerPartition: Option[Int] = None
-                                     , forceRetainStorageHistory: Option[Boolean] = None) {
-  val retainStorageHistory: Boolean = forceRetainStorageHistory.getOrElse(lastUpdatedColumn.isDefined)
-}
+                                     , forceRetainStorageHistory: Option[Boolean] = None)

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionUtils.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMIngestionUtils.scala
@@ -101,4 +101,7 @@ object RDBMIngestionUtils {
 case class RDBMExtractionTableConfig(tableName: String
                                      , pkCols: Option[Seq[String]] = None
                                      , lastUpdatedColumn: Option[String] = None
-                                     , maxRowsPerPartition: Option[Int] = None)
+                                     , maxRowsPerPartition: Option[Int] = None
+                                     , forceRetainStorageHistory: Option[Boolean] = None) {
+  val retainStorageHistory: Boolean = forceRetainStorageHistory.getOrElse(lastUpdatedColumn.isDefined)
+}

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
@@ -4,7 +4,7 @@ import java.util.Properties
 
 import com.coxautodata.waimak.log.Logging
 import com.coxautodata.waimak.storage.AuditTableInfo
-import org.apache.spark.sql.{SparkSession}
+import org.apache.spark.sql.SparkSession
 
 import scala.util.{Failure, Success, Try}
 
@@ -75,15 +75,20 @@ class SQLServerExtractor(override val sparkSession: SparkSession
 
   override def getTableMetadata(dbSchemaName: String
                                 , tableName: String
-                                , primaryKeys: Option[Seq[String]] = None
-                                , lastUpdatedColumn: Option[String] = None): Try[AuditTableInfo] = {
+                                , primaryKeys: Option[Seq[String]]
+                                , lastUpdatedColumn: Option[String]
+                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
     ((primaryKeys, getTablePKs(dbSchemaName, transformTableNameForRead(tableName))) match {
       case (Some(userPKs), Some(pksFromDB)) if userPKs.sorted != pksFromDB.sorted =>
         Failure(IncorrectUserPKException(userPKs, pksFromDB))
       case (Some(userPKs), None) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
       case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
-    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString)))
+    }).map(meta => AuditTableInfo(meta.tableName
+      , meta.primaryKeys
+      , RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString)
+      , retainStorageHistory
+    ))
   }
 
   def getTablePKs(dbSchemaName: String

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
@@ -77,7 +77,7 @@ class SQLServerExtractor(override val sparkSession: SparkSession
                                 , tableName: String
                                 , primaryKeys: Option[Seq[String]]
                                 , lastUpdatedColumn: Option[String]
-                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
+                                , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo] = {
     ((primaryKeys, getTablePKs(dbSchemaName, transformTableNameForRead(tableName))) match {
       case (Some(userPKs), Some(pksFromDB)) if userPKs.sorted != pksFromDB.sorted =>
         Failure(IncorrectUserPKException(userPKs, pksFromDB))
@@ -87,7 +87,7 @@ class SQLServerExtractor(override val sparkSession: SparkSession
     }).map(meta => AuditTableInfo(meta.tableName
       , meta.primaryKeys
       , RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString)
-      , retainStorageHistory
+      , retainStorageHistory(meta.lastUpdatedColumn)
     ))
   }
 

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
@@ -71,7 +71,7 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
                                 , tableName: String
                                 , primaryKeys: Option[Seq[String]]
                                 , lastUpdatedColumn: Option[String]
-                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
+                                , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo] = {
     lastUpdatedColumn.foreach(col => logWarning(
       s"Ignoring user-passed value for last updated ($col) " +
         s"as we can get this information from the database"))
@@ -83,7 +83,7 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
         primaryKeys match {
           case Some(userPks) if userPks.sorted != pkCols.sorted =>
             Failure(IncorrectUserPKException(userPks, pkCols))
-          case _ => Success(AuditTableInfo(m.tableName, pkCols, metaMap, retainStorageHistory))
+          case _ => Success(AuditTableInfo(m.tableName, pkCols, metaMap, retainStorageHistory(m.mainTableMetadata.lastUpdatedColumn)))
         }
       })
   }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
@@ -69,8 +69,9 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
 
   override def getTableMetadata(dbSchemaName: String
                                 , tableName: String
-                                , primaryKeys: Option[Seq[String]] = None
-                                , lastUpdatedColumn: Option[String] = None): Try[AuditTableInfo] = {
+                                , primaryKeys: Option[Seq[String]]
+                                , lastUpdatedColumn: Option[String]
+                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
     lastUpdatedColumn.foreach(col => logWarning(
       s"Ignoring user-passed value for last updated ($col) " +
         s"as we can get this information from the database"))
@@ -82,7 +83,7 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
         primaryKeys match {
           case Some(userPks) if userPks.sorted != pkCols.sorted =>
             Failure(IncorrectUserPKException(userPks, pkCols))
-          case _ => Success(AuditTableInfo(m.tableName, pkCols, metaMap))
+          case _ => Success(AuditTableInfo(m.tableName, pkCols, metaMap, retainStorageHistory))
         }
       })
   }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
@@ -21,13 +21,14 @@ class SQLServerViewExtractor(override val sparkSession: SparkSession
 
   override def getTableMetadata(dbSchemaName: String
                                 , tableName: String
-                                , primaryKeys: Option[Seq[String]] = None
-                                , lastUpdatedColumn: Option[String] = None): Try[AuditTableInfo] = {
+                                , primaryKeys: Option[Seq[String]]
+                                , lastUpdatedColumn: Option[String]
+                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
     (primaryKeys match {
       case Some(userPKS) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKS, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
     }).map(meta => {
-      AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString))
+      AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory)
     })
   }
 }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
@@ -23,12 +23,12 @@ class SQLServerViewExtractor(override val sparkSession: SparkSession
                                 , tableName: String
                                 , primaryKeys: Option[Seq[String]]
                                 , lastUpdatedColumn: Option[String]
-                                , retainStorageHistory: Boolean): Try[AuditTableInfo] = {
+                                , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo] = {
     (primaryKeys match {
       case Some(userPKS) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKS, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
     }).map(meta => {
-      AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory)
+      AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn))
     })
   }
 }

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractorIntegrationTest.scala
@@ -82,42 +82,47 @@ class PostgresExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAnd
   describe("getTableMetadata") {
     it("should return the metadata from the database (no user metadata provided)") {
       val postgresExtractor = new PostgresExtractor(sparkSession, postgresConnectionDetails)
-      postgresExtractor.getTableMetadata("public", "table_a", None, None) should be(Success(
+      postgresExtractor.getTableMetadata("public", "table_a", None, None, true) should be(Success(
         AuditTableInfo("table_a", Seq("table_a_pk"), Map(
           "schemaName" -> "public"
           , "tableName" -> "table_a"
           , "primaryKeys" -> "table_a_pk")
+          , true
         )))
     }
     it("should return the metadata from the database with the provided last updated included") {
       val postgresExtractor = new PostgresExtractor(sparkSession, postgresConnectionDetails)
-      postgresExtractor.getTableMetadata("public", "table_a", None, Some("table_a_last_updated")) should be(Success(
+      postgresExtractor.getTableMetadata("public", "table_a", None, Some("table_a_last_updated"), true) should be(Success(
         AuditTableInfo("table_a", Seq("table_a_pk"), Map(
           "schemaName" -> "public"
           , "tableName" -> "table_a"
           , "primaryKeys" -> "table_a_pk"
           , "lastUpdatedColumn" -> "table_a_last_updated"
-        ))))
+        )
+          , true
+        )))
     }
     it("should fail if the user-provided pks differ from the ones found in the database") {
       val postgresExtractor = new PostgresExtractor(sparkSession, postgresConnectionDetails)
-      postgresExtractor.getTableMetadata("public", "table_a", Some(Seq("incorrect_pk")), None) should be(Failure(
+      postgresExtractor.getTableMetadata("public", "table_a", Some(Seq("incorrect_pk")), None, true) should be(Failure(
         IncorrectUserPKException(Seq("incorrect_pk"), Seq("table_a_pk"))
       ))
     }
     it("should return the metadata if the user-provided pks match the ones from the database") {
       val postgresExtractor = new PostgresExtractor(sparkSession, postgresConnectionDetails)
-      postgresExtractor.getTableMetadata("public", "table_a", Some(Seq("table_a_pk")), Some("table_a_last_updated")) should be(Success(
+      postgresExtractor.getTableMetadata("public", "table_a", Some(Seq("table_a_pk")), Some("table_a_last_updated"), true) should be(Success(
         AuditTableInfo("table_a", Seq("table_a_pk"), Map(
           "schemaName" -> "public"
           , "tableName" -> "table_a"
           , "primaryKeys" -> "table_a_pk"
           , "lastUpdatedColumn" -> "table_a_last_updated"
-        ))))
+        )
+          , true
+        )))
     }
     it("should fail if pks are not provided and they cannot be found in the database") {
       val postgresExtractor = new PostgresExtractor(sparkSession, postgresConnectionDetails)
-      postgresExtractor.getTableMetadata("public", "tabledoesnotexist", None, Some("table_a_last_updated")) should be(Failure(
+      postgresExtractor.getTableMetadata("public", "tabledoesnotexist", None, Some("table_a_last_updated"), true) should be(Failure(
         PKsNotFoundOrProvidedException
       ))
     }

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractorIntegrationTest.scala
@@ -7,9 +7,6 @@ import com.coxautodata.waimak.dataflow.Waimak
 import com.coxautodata.waimak.dataflow.spark.SparkAndTmpDirSpec
 import com.coxautodata.waimak.rdbm.ingestion.RDBMIngestionActions._
 import com.coxautodata.waimak.storage.AuditTableInfo
-import com.coxautodata.waimak.storage.StorageActions._
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.functions.max
 import org.scalatest.BeforeAndAfterAll
 
 import scala.util.{Failure, Success}
@@ -84,43 +81,47 @@ class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAn
 
     it("should return the metadata from the database (no user metadata provided)") {
       val sqlServerExtractor = new SQLServerExtractor(sparkSession, sqlServerConnectionDetails)
-      sqlServerExtractor.getTableMetadata("dbo", "testtable", None, None) should be(Success(
+      sqlServerExtractor.getTableMetadata("dbo", "testtable", None, None, true) should be(Success(
         AuditTableInfo("testtable", Seq("testtableid1", "testtableid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testtable"
           , "primaryKeys" -> "testtableid1,testtableid2"
-        ))))
+        )
+          , true
+        )))
     }
 
     it("should fail if the user-provided pks differ from the ones found in the database") {
       val sqlServerExtractor = new SQLServerExtractor(sparkSession, sqlServerConnectionDetails)
-      sqlServerExtractor.getTableMetadata("dbo", "testtable", Some(Seq("incorrect_pk")), None) should be(Failure(
+      sqlServerExtractor.getTableMetadata("dbo", "testtable", Some(Seq("incorrect_pk")), None, true) should be(Failure(
         IncorrectUserPKException(Seq("incorrect_pk"), Seq("testtableid1", "testtableid2"))
       ))
     }
     it("should return metadata if there are user-provided pks but table pk's not specified in the database") {
       val sqlServerExtractor = new SQLServerExtractor(sparkSession, sqlServerConnectionDetails)
-      sqlServerExtractor.getTableMetadata("dbo", "testtable_pk", Some(Seq("testtableid1", "testtableid2")), None) should be(Success(
+      sqlServerExtractor.getTableMetadata("dbo", "testtable_pk", Some(Seq("testtableid1", "testtableid2")), None, true) should be(Success(
         AuditTableInfo("testtable_pk", Seq("testtableid1", "testtableid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testtable_pk"
           , "primaryKeys" -> "testtableid1,testtableid2"
-      ))))
+        )
+          , true)))
     }
     it("should fail if no user-provided pks and table pk's specified in the database") {
       val sqlServerExtractor = new SQLServerExtractor(sparkSession, sqlServerConnectionDetails)
-      sqlServerExtractor.getTableMetadata("dbo", "testtable_pk", None, None) should be(Failure(
+      sqlServerExtractor.getTableMetadata("dbo", "testtable_pk", None, None, true) should be(Failure(
         PKsNotFoundOrProvidedException
       ))
     }
     it("should return the metadata if the user-provided pks match the ones from the database") {
       val sqlServerExtractor = new SQLServerExtractor(sparkSession, sqlServerConnectionDetails)
-      sqlServerExtractor.getTableMetadata("dbo", "testtable", Some(Seq("testtableid1", "testtableid2"))) should be(Success(
+      sqlServerExtractor.getTableMetadata("dbo", "testtable", Some(Seq("testtableid1", "testtableid2")), None, true) should be(Success(
         AuditTableInfo("testtable", Seq("testtableid1", "testtableid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testtable"
           , "primaryKeys" -> "testtableid1,testtableid2"
-        ))))
+        )
+          , true)))
     }
 
   }
@@ -128,7 +129,6 @@ class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAn
 
     it("should extract from the db to the storage layer") {
       val spark = sparkSession
-      import spark.implicits._
       val sqlExtractor = new SQLServerExtractor(sparkSession, sqlServerConnectionDetails)
       val flow = Waimak.sparkFlow(sparkSession)
       val executor = Waimak.sparkExecutor()

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
@@ -100,7 +100,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
       sqlServerExtractor.allTableMetadata("dbo.testtemporal") should be(
         SQLServerTemporalTableMetadata("dbo", "testtemporal", Some("dbo"), Some("testtemporalhistory"), Some("sysstarttime"), Some("sysendtime"), "testtemporalid"))
 
-      sqlServerExtractor.getTableMetadata("dbo", "testtemporal") should be(
+      sqlServerExtractor.getTableMetadata("dbo", "testtemporal", None, None, true) should be(
         Success(AuditTableInfo("testtemporal", Seq("testtemporalid"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testtemporal"
@@ -108,7 +108,8 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
           , "historyTableSchema" -> "dbo"
           , "historyTableName" -> "testtemporalhistory"
           , "startColName" -> "sysstarttime"
-          , "endColName" -> "sysendtime")))
+          , "endColName" -> "sysendtime")
+          , true))
       )
     }
 
@@ -119,11 +120,12 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
         SQLServerTemporalTableMetadata("dbo", "testnontemporal", None, None, None, None, "testnontemporalid1;testnontemporalid2")
       )
 
-      sqlServerExtractor.getTableMetadata("dbo", "testnontemporal") should be(
+      sqlServerExtractor.getTableMetadata("dbo", "testnontemporal", None, None, true) should be(
         Success(AuditTableInfo("testnontemporal", Seq("testnontemporalid1", "testnontemporalid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testnontemporal"
-          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2")))
+          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2")
+          , true))
       )
     }
   }

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
@@ -100,7 +100,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
       sqlServerExtractor.allTableMetadata("dbo.testtemporal") should be(
         SQLServerTemporalTableMetadata("dbo", "testtemporal", Some("dbo"), Some("testtemporalhistory"), Some("sysstarttime"), Some("sysendtime"), "testtemporalid"))
 
-      sqlServerExtractor.getTableMetadata("dbo", "testtemporal", None, None, true) should be(
+      sqlServerExtractor.getTableMetadata("dbo", "testtemporal", None, None, None) should be(
         Success(AuditTableInfo("testtemporal", Seq("testtemporalid"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testtemporal"
@@ -120,12 +120,35 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
         SQLServerTemporalTableMetadata("dbo", "testnontemporal", None, None, None, None, "testnontemporalid1;testnontemporalid2")
       )
 
-      sqlServerExtractor.getTableMetadata("dbo", "testnontemporal", None, None, true) should be(
+      sqlServerExtractor.getTableMetadata("dbo", "testnontemporal", None, None, None) should be(
+        Success(AuditTableInfo("testnontemporal", Seq("testnontemporalid1", "testnontemporalid2"), Map(
+          "schemaName" -> "dbo"
+          , "tableName" -> "testnontemporal"
+          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2")
+          , false))
+      )
+    }
+    it("should apply the forceRetainStorageHistory flag to the retrieved metadata") {
+      val sqlServerExtractor = new SQLServerTemporalExtractor(sparkSession, sqlServerConnectionDetails)
+
+      sqlServerExtractor.getTableMetadata("dbo", "testnontemporal", None, None, Some(true)) should be(
         Success(AuditTableInfo("testnontemporal", Seq("testnontemporalid1", "testnontemporalid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testnontemporal"
           , "primaryKeys" -> "testnontemporalid1;testnontemporalid2")
           , true))
+      )
+
+      sqlServerExtractor.getTableMetadata("dbo", "testtemporal", None, None, Some(false)) should be(
+        Success(AuditTableInfo("testtemporal", Seq("testtemporalid"), Map(
+          "schemaName" -> "dbo"
+          , "tableName" -> "testtemporal"
+          , "primaryKeys" -> "testtemporalid"
+          , "historyTableSchema" -> "dbo"
+          , "historyTableName" -> "testtemporalhistory"
+          , "startColName" -> "sysstarttime"
+          , "endColName" -> "sysendtime")
+          , false))
       )
     }
   }

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestRDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestRDBMExtractor.scala
@@ -120,11 +120,11 @@ object TExtractor extends RDBMExtractor {
 
   override def sourceDBSystemTimestampFunction: String = "CURRENT_TIMESTAMP"
 
-  override def getTableMetadata(dbSchemaName: String, tableName: String, primaryKeys: Option[Seq[String]], lastUpdatedColumn: Option[String], retainStorageHistory: Boolean): Try[AuditTableInfo] = ???
-
   override def extraConnectionProperties: Properties = ???
 
   override def escapeKeyword(identifier: String): String = s"[$identifier]"
+
+  override protected def getTableMetadata(dbSchemaName: String, tableName: String, primaryKeys: Option[Seq[String]], lastUpdatedColumn: Option[String], retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo] = ???
 }
 
 

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestRDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestRDBMExtractor.scala
@@ -120,7 +120,7 @@ object TExtractor extends RDBMExtractor {
 
   override def sourceDBSystemTimestampFunction: String = "CURRENT_TIMESTAMP"
 
-  override def getTableMetadata(dbSchemaName: String, tableName: String, primaryKeys: Option[Seq[String]], lastUpdatedColumn: Option[String]): Try[AuditTableInfo] = ???
+  override def getTableMetadata(dbSchemaName: String, tableName: String, primaryKeys: Option[Seq[String]], lastUpdatedColumn: Option[String], retainStorageHistory: Boolean): Try[AuditTableInfo] = ???
 
   override def extraConnectionProperties: Properties = ???
 

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestSQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestSQLServerViewExtractor.scala
@@ -1,0 +1,65 @@
+package com.coxautodata.waimak.rdbm.ingestion
+
+import com.coxautodata.waimak.dataflow.spark.SparkSpec
+import com.coxautodata.waimak.storage.AuditTableInfo
+
+import scala.util.{Failure, Success}
+
+class TestSQLServerViewExtractor extends SparkSpec {
+
+  override val appName: String = "TestSQLServerViewExtractor"
+
+  val sqlServerConnectionDetails: SQLServerConnectionDetails = SQLServerConnectionDetails("localhost", 1401, "master", "SA", "SQLServer123!")
+
+  describe("getTableMetadata") {
+    it("should use the provided values for the primary keys and lastUpdated") {
+      val sqlServerViewExtractor = new SQLServerViewExtractor(sparkSession, sqlServerConnectionDetails)
+      sqlServerViewExtractor.getTableMetadata("testSchema"
+        , "testTable"
+        , Some(Seq("key1", "key2"))
+        , Some("lastUpdated")
+        , None) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
+        "schemaName" -> "testSchema"
+        , "tableName" -> "testTable"
+        , "primaryKeys" -> "key1,key2"
+        , "lastUpdatedColumn" -> "lastUpdated")
+        , true
+      )))
+    }
+
+    it("should apply the forceRetainStorageHistory flag to the retrieved metadata") {
+      val sqlServerViewExtractor = new SQLServerViewExtractor(sparkSession, sqlServerConnectionDetails)
+      sqlServerViewExtractor.getTableMetadata("testSchema"
+        , "testTable"
+        , Some(Seq("key1", "key2"))
+        , Some("lastUpdated")
+        , Some(false)) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
+        "schemaName" -> "testSchema"
+        , "tableName" -> "testTable"
+        , "primaryKeys" -> "key1,key2"
+        , "lastUpdatedColumn" -> "lastUpdated")
+        , false
+      )))
+
+      sqlServerViewExtractor.getTableMetadata("testSchema"
+        , "testTable"
+        , Some(Seq("key1", "key2"))
+        , None
+        , Some(true)) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
+        "schemaName" -> "testSchema"
+        , "tableName" -> "testTable"
+        , "primaryKeys" -> "key1,key2")
+        , true
+      )))
+    }
+
+    it("should fail if no pks are provided") {
+      val sqlServerViewExtractor = new SQLServerViewExtractor(sparkSession, sqlServerConnectionDetails)
+      sqlServerViewExtractor.getTableMetadata("testSchema"
+        , "testTable"
+        , None
+        , Some("lastUpdated")
+        , None) should be(Failure(PKsNotFoundOrProvidedException))
+    }
+  }
+}

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
@@ -37,7 +37,7 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     */
   protected var wasModified = false
 
-  protected val tablePath = new Path(baseFolder, tableInfo.table_name)
+  protected[storage] val tablePath = new Path(baseFolder, tableInfo.table_name)
 
   protected[storage] val regionInfoBasePath = new Path(baseFolder, AuditTableFile.REGION_INFO_DIRECTORY)
 
@@ -71,13 +71,14 @@ class AuditTableFile(val tableInfo: AuditTableInfo
 
   override def snapshot(ts: Timestamp): Option[Dataset[_]] = {
     //TODO: optimise and explore other solutions with the use of counts, as smaller counts should avoid shuffle, hot applied to cold
-    val auditRows = allBetween(None, Some(ts))
-    auditRows.map { rows =>
-      val primaryKeyColumns = tableInfo.primary_keys.map(rows(_))
-      val windowLatest = Window.partitionBy(primaryKeyColumns: _*).orderBy(rows(DE_LAST_UPDATED_COLUMN).desc)
-      rows.withColumn("_rowNum", row_number().over(windowLatest)).filter("_rowNum = 1").drop("_rowNum")
-        .drop(DE_LAST_UPDATED_COLUMN)
-    }
+    allBetween(None, Some(ts)).map(deduplicate)
+  }
+
+  def deduplicate(ds: Dataset[_]): Dataset[_] = {
+    val primaryKeyColumns = tableInfo.primary_keys.map(ds(_))
+    val windowLatest = Window.partitionBy(primaryKeyColumns: _*).orderBy(ds(DE_LAST_UPDATED_COLUMN).desc)
+    ds.withColumn("_rowNum", row_number().over(windowLatest)).filter("_rowNum = 1").drop("_rowNum")
+      .drop(DE_LAST_UPDATED_COLUMN)
   }
 
   /**
@@ -167,7 +168,7 @@ class AuditTableFile(val tableInfo: AuditTableInfo
                             , compactionPartitioner: CompactionPartitioner
                             , recompactAll: Boolean): Try[AuditTableFile] = {
     val smallerRegions =
-      if (recompactAll) regions
+      if (recompactAll || !tableInfo.retain_history) regions
       else regions.filter(r => r.store_type == COLD_PARTITION && r.count < smallRegionRowThreshold)
     // No use compacting a single small region into itself
     compactRegions(coldPath, if (smallerRegions.length < 2 && !recompactAll) Seq.empty else smallerRegions, compactTS, compactionPartitioner)
@@ -186,7 +187,10 @@ class AuditTableFile(val tableInfo: AuditTableInfo
         logInfo(s"Compacting regions ${ids.mkString("[", ", ", "]")} in path [${regionPath.toString}]")
         if (storageOps.pathExists(regionPath)) throw StorageException(s"Can not compact table [$tableName], as path [${regionPath.toString}] already exists")
 
-        val data = storageOps.openParquet(typePath)
+        val data = storageOps.openParquet(typePath).map {
+          case ds if !tableInfo.retain_history => deduplicate(ds)
+          case ds => ds
+        }
         val newRegionSet = data.map { rows =>
           //Clear current region info to prevent corruption on failure
           clearTableRegionCache(this)

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
@@ -467,12 +467,14 @@ object AuditTableFile extends Logging {
 /**
   * Static information about the table, that is persisted when audit table is initialised.
   *
-  * @param table_name   name of the table
-  * @param primary_keys list of columns that make up primary key, these will be used for snapshot generation and
-  *                     record deduplication
-  * @param meta         application/custom metadata that will not be used in this library.
+  * @param table_name     name of the table
+  * @param primary_keys   list of columns that make up primary key, these will be used for snapshot generation and
+  *                       record deduplication
+  * @param retain_history whether to retain history for this table. If set to false, the table will be deduplicated
+  *                       on every compaction
+  * @param meta           application/custom metadata that will not be used in this library.
   */
-case class AuditTableInfo(table_name: String, primary_keys: Seq[String], meta: Map[String, String])
+case class AuditTableInfo(table_name: String, primary_keys: Seq[String], meta: Map[String, String], retain_history: Boolean)
 
 /**
   *

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
@@ -53,7 +53,7 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
   )
 
   def createADTable(tableName: String, fosp: FileStorageOps): AuditTableFile = {
-    new AuditTableFile(AuditTableInfo(tableName, Seq("id"), Map.empty), Seq.empty, fosp, basePath, sequence())
+    new AuditTableFile(AuditTableInfo(tableName, Seq("id"), Map.empty, true), Seq.empty, fosp, basePath, sequence())
   }
 
   val defaultCompactionPartitioner: CompactionPartitioner = (_, _) => 1
@@ -87,7 +87,7 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
       inferredRegions should be(Seq.empty)
 
       val infoData = zeroState.storageOps.readAuditTableInfo(basePath, tableName)
-      infoData should be(Success(AuditTableInfo(tableName, Seq("id"), Map.empty)))
+      infoData should be(Success(AuditTableInfo(tableName, Seq("id"), Map.empty, true)))
     }
 
     it("init table fail") {
@@ -102,7 +102,7 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
 
     it("init table fail, no keys") {
 
-      val zeroState = new AuditTableFile(AuditTableInfo(tableName, Seq.empty, Map.empty), Seq.empty, createFops(), basePath, sequence())
+      val zeroState = new AuditTableFile(AuditTableInfo(tableName, Seq.empty, Map.empty, true), Seq.empty, createFops(), basePath, sequence())
 
       val res = zeroState.initNewTable()
 
@@ -536,7 +536,7 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
       tables.size should be(1)
       tables.get("prsn").map(_.get.tableName) should be(Some("prsn"))
       tables.get("prsn").map(_.get.regions.size) should be(Some(0))
-      tables.get("prsn").map(_.get.tableInfo) should be(Some(AuditTableInfo("prsn", Seq("id"), Map.empty)))
+      tables.get("prsn").map(_.get.tableInfo) should be(Some(AuditTableInfo("prsn", Seq("id"), Map.empty, true)))
 
       missing should be(Seq("missing"))
     }

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -37,7 +37,7 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       val writeFlow = Waimak.sparkFlow(spark)
         .addInput("t_record", Some(records.toDS()))
-        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty)))("t_record")
+        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty, true)))("t_record")
         .writeToStorage("t_record", "lastUpdated", zdt1)
 
       executor.execute(writeFlow)
@@ -82,7 +82,7 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       val writeFlow = Waimak.sparkFlow(spark)
         .addInput("t_record", Some(records.toDS()))
-        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty)))("t_record")
+        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty, true)))("t_record")
         .writeToStorage("t_record", "lastUpdated", laZts, runSingleCompactionDuringWindow(10, 11))
 
       executor.execute(writeFlow)
@@ -117,7 +117,7 @@ class TestStorageActions extends SparkAndTmpDirSpec {
 
       val writeFlow = Waimak.sparkFlow(spark)
         .addInput("t_record", Some(records.toDS()))
-        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty)))("t_record")
+        .getOrCreateAuditTable(testingBaseDirName, Some(_ => AuditTableInfo("t_record", Seq("id"), Map.empty, true)))("t_record")
         .writeToStorage("t_record", "lastUpdated", laZts)
 
       executor.execute(writeFlow)


### PR DESCRIPTION
# Description

Adds an option to not retain storage history for specific tables, and as such for them to be deduplicated when compaction happens. This is useful for keeping storage size down in situations where you may have a large number of duplicates in the table, for example lookup tables which are extracted into the storage layer in full every time.

For RDBM extraction, the default behaviour is to retain history for tables which have a lastUpdated column, and to not retain history for those without. The choice of this default behaviour is because,  without a lastUpdatedColumn, the table will be extracted in full every time extraction is performed, causing the size of the data in storage to grow uncontrollably. To override this behaviour, you will need to set `forceRetainStorageHistory` on the `RDBMExtractionTableConfig` for each table.

Fixes #64 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

This is mostly non-breaking, however an additional, non-optional field has been added to `AuditTableInfo`, so direct instantiations of this will break.

# How Has This Been Tested?

Updated existing unit tests and added new ones.
