### PR TITLE
Change force recreate tables flag to waimak configuration parameter

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
@@ -98,6 +98,18 @@ trait DataFlow extends Logging {
   def mapOption[R >: this.type](f: this.type => Option[R]): R = f(this).getOrElse(this)
 
   /**
+    * Fold left over a collection, where the current DataFlow is the zero value.
+    * Lets you fold over a flow inline in the flow.
+    *
+    * @param foldOver Collection to fold over
+    * @param f        Function to apply during the flow
+    * @return A DataFlow produced after repeated applications of f for each element in the collection
+    */
+  def foldLeftOver[A, S >: this.type <: DataFlow](foldOver: Iterable[A])(f: (S, A) => S): S = {
+    foldOver.foldLeft[S](this)(f)
+  }
+
+  /**
     * Creates new state of the dataflow by adding an input.
     * Duplicate labels are handled in [[prepareForExecution()]]
     *

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/metastore/MetastoreUtils.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/metastore/MetastoreUtils.scala
@@ -3,6 +3,7 @@ package com.coxautodata.waimak.metastore
 import java.sql.{Connection, DriverManager, ResultSet}
 
 import com.coxautodata.waimak.dataflow.DataFlowException
+import com.coxautodata.waimak.dataflow.spark.SparkFlowContext
 import com.coxautodata.waimak.log.Logging
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.security.alias.CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH
@@ -133,11 +134,14 @@ trait JDBCConnector extends DBConnector {
   * table functions (i.e. create parquet tables)
   */
 trait HadoopDBConnector extends DBConnector {
+  import HadoopDBConnector._
+
+  def context: SparkFlowContext
 
   /**
     * Force drop+create of tables even if update is called (necessary in cases of schema change)
     */
-  def forceRecreateTables: Boolean
+  def forceRecreateTables: Boolean = context.getBoolean(FORCE_RECREATE_TABLES, FORCE_RECREATE_TABLES_DEFAULT)
 
   private[metastore] def createTableFromParquetDDL(tableName: String, path: String, external: Boolean = true, partitionColumns: Seq[String] = Seq.empty, ifNotExists: Boolean = true): Seq[String]
 
@@ -180,4 +184,15 @@ trait HadoopDBConnector extends DBConnector {
       else createTableFromParquetDDL(tableName, path) :+ updateTableLocationDDL(tableName, path)
     }
   }
+}
+
+object HadoopDBConnector {
+    val metastoreParamPrefix: String = "spark.waimak.metastore"
+    /**
+      * Force recreate (drop+create) of all tables submitted through connector objects.
+      * This should be done in case of underlying schema changes to data files.
+      * Default: false
+      */
+    val FORCE_RECREATE_TABLES: String = s"$metastoreParamPrefix.forceRecreateTables"
+    val FORCE_RECREATE_TABLES_DEFAULT: Boolean = false
 }

--- a/waimak-hive/src/main/scala/com/coxautodata/waimak/metastore/HiveDBConnector.scala
+++ b/waimak-hive/src/main/scala/com/coxautodata/waimak/metastore/HiveDBConnector.scala
@@ -4,22 +4,17 @@ import java.sql.ResultSet
 
 import com.coxautodata.waimak.dataflow.DataFlowException
 import com.coxautodata.waimak.dataflow.spark.SparkFlowContext
-import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.sql.SparkSession
+import org.apache.hadoop.fs.Path
 
 /**
   * Hive trait that implements the Hive-specific HadoopDBConnector functions
   */
 trait HiveDBConnector extends HadoopDBConnector {
 
-  def sparkSession: SparkSession
-
-  def fileSystem: FileSystem
-
   private[metastore] override def createTableFromParquetDDL(tableName: String, pathWithoutUri: String, external: Boolean, partitionColumns: Seq[String], ifNotExists: Boolean = true): Seq[String] = {
 
     // Qualify the path for this filesystem
-    val path = new Path(pathWithoutUri).makeQualified(fileSystem.getUri, fileSystem.getWorkingDirectory)
+    val path = new Path(pathWithoutUri).makeQualified(context.fileSystem.getUri, context.fileSystem.getWorkingDirectory)
 
     //Find glob paths catering for partitions
     val globPath = {
@@ -28,7 +23,7 @@ trait HiveDBConnector extends HadoopDBConnector {
     }
 
     logInfo("Get paths for ddls " + globPath.toString)
-    val parquetFile = fileSystem.globStatus(globPath).sortBy(_.getPath.toUri.getPath).headOption.map(_.getPath).getOrElse(throw new DataFlowException(s"Could not find parquet file at " +
+    val parquetFile = context.fileSystem.globStatus(globPath).sortBy(_.getPath.toUri.getPath).headOption.map(_.getPath).getOrElse(throw new DataFlowException(s"Could not find parquet file at " +
       s"'$path' to infer schema for table '$tableName'"))
 
     //Create ddl
@@ -47,12 +42,13 @@ trait HiveDBConnector extends HadoopDBConnector {
   }
 
   override private[metastore] def updateTableLocationDDL(tableName: String, pathWithoutUri: String): String = {
-    val path = new Path(pathWithoutUri).makeQualified(fileSystem.getUri, fileSystem.getWorkingDirectory)
+    val path = new Path(pathWithoutUri).makeQualified(context.fileSystem.getUri, context.fileSystem.getWorkingDirectory)
     s"alter table $tableName set location '$path'"
   }
 
   private[metastore] def getSchema(parquetFile: Path): String = {
-    sparkSession
+    context
+      .spark
       .read
       .parquet(parquetFile.toString)
       .schema
@@ -68,17 +64,13 @@ trait HiveDBConnector extends HadoopDBConnector {
   * the DDLs and run them manually.
   *
   */
-case class HiveDummyConnector(sparkFlowContext: SparkFlowContext, forceRecreateTables: Boolean = false) extends HiveDBConnector {
+case class HiveDummyConnector(context: SparkFlowContext) extends HiveDBConnector {
   var ranDDLs: List[List[String]] = List.empty
 
   override private[metastore] def runQueries(ddls: Seq[String]): Seq[Option[ResultSet]] = {
     ranDDLs = ranDDLs :+ ddls.toList
     Seq(None)
   }
-
-  override def sparkSession: SparkSession = sparkFlowContext.spark
-
-  override def fileSystem: FileSystem = sparkFlowContext.fileSystem
 }
 
 /**
@@ -87,20 +79,18 @@ case class HiveDummyConnector(sparkFlowContext: SparkFlowContext, forceRecreateT
   * The connector uses the filesystem configured in the SparkFlowContext to discover
   * partitions therefore table paths must exist on that filesystem.
   *
-  * @param sparkFlowContext          The flow context object containing the SparkSession and FileSystem
+  * @param context                   The flow context object containing the SparkSession and FileSystem
   * @param database                  Database to create tables in
   * @param createDatabaseIfNotExists Whether to create the database if it does not exist (default false)
-  * @param forceRecreateTables       Whether tables should be dropped and recreated (in case of schema changes)
   */
-case class HiveSparkSQLConnector(sparkFlowContext: SparkFlowContext,
+case class HiveSparkSQLConnector(context: SparkFlowContext,
                                  database: String,
-                                 createDatabaseIfNotExists: Boolean = false,
-                                 forceRecreateTables: Boolean = false) extends HiveDBConnector {
+                                 createDatabaseIfNotExists: Boolean = false) extends HiveDBConnector {
 
   override def submitAtomicResultlessQueries(ddls: Seq[String]): Unit = {
     val ddlWithUse = s"use $database" +: ddls
     val allDdls = if (createDatabaseIfNotExists) s"create database if not exists $database" +: ddlWithUse else ddlWithUse
-    allDdls.foreach(sparkSession.sql)
+    allDdls.foreach(context.spark.sql)
     Unit
   }
 
@@ -108,7 +98,4 @@ case class HiveSparkSQLConnector(sparkFlowContext: SparkFlowContext,
     throw new UnsupportedOperationException(s"${this.getClass.getSimpleName} does not support running queries that return data. You must use SparkSession.sql directly.")
   }
 
-  override def sparkSession: SparkSession = sparkFlowContext.spark
-
-  override def fileSystem: FileSystem = sparkFlowContext.fileSystem
 }

--- a/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
+++ b/waimak-impala/src/main/scala/com/coxautodata/waimak/metastore/ImpalaDBConnector.scala
@@ -5,19 +5,14 @@ import java.sql.ResultSet
 import com.coxautodata.waimak.dataflow.DataFlowException
 import com.coxautodata.waimak.dataflow.spark.SparkFlowContext
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
 
 
 /**
   * Impala trait that implements the Impala-specific HadoopDBConnector functions
   */
 trait ImpalaDBConnector extends HadoopDBConnector {
-
-  def sparkSession: SparkSession
-
-  def fileSystem: FileSystem
 
   private[metastore] override def createTableFromParquetDDL(tableName: String, path: String, external: Boolean, partitionColumns: Seq[String], ifNotExists: Boolean = true): Seq[String] = {
     //Find glob paths catering for partitions
@@ -27,7 +22,7 @@ trait ImpalaDBConnector extends HadoopDBConnector {
     }
 
     logInfo("Get paths for ddls " + globPath.toString)
-    val parquetFile = fileSystem.globStatus(globPath).sortBy(_.getPath.toUri.getPath).headOption.map(_.getPath).getOrElse(throw new DataFlowException(s"Could not find parquet file at " +
+    val parquetFile = context.fileSystem.globStatus(globPath).sortBy(_.getPath.toUri.getPath).headOption.map(_.getPath).getOrElse(throw new DataFlowException(s"Could not find parquet file at " +
       s"'$path' to infer schema for table '$tableName'"))
 
     //Create ddl
@@ -48,58 +43,46 @@ trait ImpalaDBConnector extends HadoopDBConnector {
 /**
   * Impala Database connector that is constructed using the Waimak JDBC template in spark conf
   *
-  * @param sparkFlowContext    The flow context object containing the SparkSession and FileSystem
-  * @param database            name of the database to connect to
-  * @param cluster             the cluster label in the JDBC template string
-  * @param forceRecreateTables Force drop+create of tables even if update is called (necessary in cases of schema change)
-  * @param properties          Key value pairs passed as connection arguments to the DriverManager during connection
-  * @param secureProperties    Key value set of parameters used to get parameter values for JDBC properties
-  *                            from a secure jceks file at CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH.
-  *                            First value is the key of the parameter in the jceks file and the second parameter
-  *                            is the key of the parameter you want in jdbc properties
+  * @param context          The flow context object containing the SparkSession and FileSystem
+  * @param database         name of the database to connect to
+  * @param cluster          the cluster label in the JDBC template string
+  * @param properties       Key value pairs passed as connection arguments to the DriverManager during connection
+  * @param secureProperties Key value set of parameters used to get parameter values for JDBC properties
+  *                         from a secure jceks file at CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH.
+  *                         First value is the key of the parameter in the jceks file and the second parameter
+  *                         is the key of the parameter you want in jdbc properties
   *
   */
-case class ImpalaWaimakJDBCConnector(sparkFlowContext: SparkFlowContext,
+case class ImpalaWaimakJDBCConnector(context: SparkFlowContext,
                                      database: String,
                                      cluster: String = "default",
-                                     forceRecreateTables: Boolean = false,
                                      properties: java.util.Properties = new java.util.Properties(),
                                      secureProperties: Map[String, String] = Map.empty) extends ImpalaDBConnector with WaimakJDBCConnector {
   override val driverName: String = "org.apache.hive.jdbc.HiveDriver"
-  override val sparkConf: SparkConf = sparkSession.sparkContext.getConf
+  override val sparkConf: SparkConf = context.spark.sparkContext.getConf
   override val service: String = "impala"
 
-  override def sparkSession: SparkSession = sparkFlowContext.spark
-
-  override def fileSystem: FileSystem = sparkFlowContext.fileSystem
-
-  override def hadoopConfiguration: Configuration = sparkSession.sparkContext.hadoopConfiguration
+  override def hadoopConfiguration: Configuration = context.spark.sparkContext.hadoopConfiguration
 }
 
 /**
   * Impala Database connector that is constructed from a JDBC connection string
   *
-  * @param sparkFlowContext    The flow context object containing the SparkSession and FileSystem
-  * @param jdbcString          the JDBC connection string
-  * @param forceRecreateTables Force drop+create of tables even if update is called (necessary in cases of schema change)
-  * @param properties          Key value pairs passed as connection arguments to the DriverManager during connection
-  * @param secureProperties    Key value set of parameters used to get parameter values for JDBC properties
-  *                            from a secure jceks file at CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH.
-  *                            First value is the key of the parameter in the jceks file and the second parameter
-  *                            is the key of the parameter you want in jdbc properties
+  * @param context          The flow context object containing the SparkSession and FileSystem
+  * @param jdbcString       the JDBC connection string
+  * @param properties       Key value pairs passed as connection arguments to the DriverManager during connection
+  * @param secureProperties Key value set of parameters used to get parameter values for JDBC properties
+  *                         from a secure jceks file at CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH.
+  *                         First value is the key of the parameter in the jceks file and the second parameter
+  *                         is the key of the parameter you want in jdbc properties
   */
-case class ImpalaJDBCConnector(sparkFlowContext: SparkFlowContext,
+case class ImpalaJDBCConnector(context: SparkFlowContext,
                                jdbcString: String,
-                               forceRecreateTables: Boolean = false,
                                properties: java.util.Properties = new java.util.Properties(),
                                secureProperties: Map[String, String] = Map.empty) extends ImpalaDBConnector with JDBCConnector {
   override val driverName: String = "org.apache.hive.jdbc.HiveDriver"
 
-  override def sparkSession: SparkSession = sparkFlowContext.spark
-
-  override def fileSystem: FileSystem = sparkFlowContext.fileSystem
-
-  override def hadoopConfiguration: Configuration = sparkSession.sparkContext.hadoopConfiguration
+  override def hadoopConfiguration: Configuration = context.spark.sparkContext.hadoopConfiguration
 }
 
 /**
@@ -108,19 +91,14 @@ case class ImpalaJDBCConnector(sparkFlowContext: SparkFlowContext,
   * This is useful for testing or using in flows where you wish to collect
   * the DDLs and run them manually.
   *
-  * @param sparkFlowContext    The flow context object containing the SparkSession and FileSystem
-  * @param forceRecreateTables Force drop+create of tables even if update is called (necessary in cases of schema change)
+  * @param context The flow context object containing the SparkSession and FileSystem
   */
-case class ImpalaDummyConnector(sparkFlowContext: SparkFlowContext, forceRecreateTables: Boolean = false) extends ImpalaDBConnector {
+case class ImpalaDummyConnector(context: SparkFlowContext) extends ImpalaDBConnector {
   var ranDDLs: List[List[String]] = List.empty
 
   override private[metastore] def runQueries(ddls: Seq[String]): Seq[Option[ResultSet]] = {
     ranDDLs = ranDDLs :+ ddls.toList
     Seq(None)
   }
-
-  override def sparkSession: SparkSession = sparkFlowContext.spark
-
-  override def fileSystem: FileSystem = sparkFlowContext.fileSystem
 
 }

--- a/waimak-impala/src/test/scala/com/coxautodata/waimak/metastore/TestImpalaDBConnector.scala
+++ b/waimak-impala/src/test/scala/com/coxautodata/waimak/metastore/TestImpalaDBConnector.scala
@@ -80,7 +80,6 @@ class TestImpalaDBConnector extends SparkAndTmpDirSpec {
 
       val connector1 = ImpalaDummyConnector(flowContext)
       val connector2 = ImpalaDummyConnector(flowContext)
-      val connectorRecreate = ImpalaDummyConnector(flowContext, forceRecreateTables = true)
 
       val baseDest = testingBaseDir + "/dest"
 
@@ -88,20 +87,15 @@ class TestImpalaDBConnector extends SparkAndTmpDirSpec {
         .openCSV(basePath)("csv_1", "csv_2")
         .alias("csv_1", "items")
         .alias("csv_2", "person")
-        .alias("csv_2", "person_recreate")
         .commit("connector1", partitions = Seq("amount"))("items")
         .commit("connector2WithSnapshot")("person")
-        .commit("connectorRecreateWithSnapshot")("person_recreate")
         .push("connector1")(ParquetDataCommitter(baseDest).withHadoopDBConnector(connector1))
         .push("connector2WithSnapshot")(ParquetDataCommitter(baseDest).withHadoopDBConnector(connector2).withSnapshotFolder("generatedTimestamp=2018-03-13-16-19-00"))
-        .push("connectorRecreateWithSnapshot")(ParquetDataCommitter(baseDest).withHadoopDBConnector(connectorRecreate).withSnapshotFolder("generatedTimestamp=2018-03-13-16-19-00"))
 
-      val (_, finalState) = executor.execute(flow)
-      finalState.inputs.size should be(5)
+      executor.execute(flow)
 
       val itemsParquet = new File(testingBaseDirName, "dest/items/amount=1").list().filter(_.endsWith(".parquet")).head
       val personParquet = new File(testingBaseDirName, "dest/person/generatedTimestamp=2018-03-13-16-19-00").list().filter(_.endsWith(".parquet")).head
-      val person_recreateParquet = new File(testingBaseDirName, "dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00").list().filter(_.endsWith(".parquet")).head
 
       connector1.ranDDLs should be {
         List(List(
@@ -118,12 +112,29 @@ class TestImpalaDBConnector extends SparkAndTmpDirSpec {
         ))
       }
 
+      import HadoopDBConnector._
+
+      spark.conf.set(FORCE_RECREATE_TABLES, "true")
+      val connectorRecreate = ImpalaDummyConnector(SparkFlowContext(spark))
+
+      val recreateFlow = SparkDataFlow.empty(sparkSession, tmpDir)
+        .openCSV(basePath)("csv_2")
+        .alias("csv_2", "person_recreate")
+        .commit("connectorRecreateWithSnapshot")("person_recreate")
+        .push("connectorRecreateWithSnapshot")(ParquetDataCommitter(baseDest).withHadoopDBConnector(connectorRecreate).withSnapshotFolder("generatedTimestamp=2018-03-13-16-19-00"))
+
+      executor.execute(recreateFlow)
+
+      val person_recreateParquet = new File(testingBaseDirName, "dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00").list().filter(_.endsWith(".parquet")).head
+
       connectorRecreate.ranDDLs should be {
         List(List(
           "drop table if exists person_recreate",
           s"create external table if not exists person_recreate like parquet 'file:$testingBaseDirName/dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00/$person_recreateParquet' stored as parquet location '$testingBaseDir/dest/person_recreate/generatedTimestamp=2018-03-13-16-19-00'"
         ))
       }
+
+
     }
 
 
@@ -134,7 +145,7 @@ class TestImpalaDBConnector extends SparkAndTmpDirSpec {
 
       val baseDest = testingBaseDir + "/dest"
 
-      val connectorRecreate = ImpalaDummyConnector(flowContext, forceRecreateTables = true)
+      val connectorRecreate = ImpalaDummyConnector(flowContext)
 
       val flowPrePush: SparkDataFlow = Waimak.sparkFlow(spark, tmpDir.toString)
         .openCSV(basePath)("csv_1", "csv_2")


### PR DESCRIPTION
# Description

This PR moves the force recreate tables flag in the HadoopDBConnector trait to a Waimak configuration option.

This PR also introduces the `foldLeftOver` on the `DataFlow` trait to make it easier to fold over a collection type using a DataFlow as a zero-value.

Fixes #65 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Unit tests