### PR TITLE
Feature/allow recreation of storage table metadata

### DIFF
--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
@@ -111,6 +111,12 @@ trait AuditTable {
     */
   def getLatestTimestamp(): Option[Timestamp]
 
+  /**
+    * Update the metadata for this table
+    *
+    * @param tableInfo the new metadata
+    * @return new state of the AuditTable
+    */
   def updateTableInfo(tableInfo: AuditTableInfo): Try[AuditTable]
 
   /**

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTable.scala
@@ -111,6 +111,8 @@ trait AuditTable {
     */
   def getLatestTimestamp(): Option[Timestamp]
 
+  def updateTableInfo(tableInfo: AuditTableInfo): Try[AuditTable]
+
   /**
     * Name of the table.
     *

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/AuditTableFile.scala
@@ -123,6 +123,10 @@ class AuditTableFile(val tableInfo: AuditTableInfo
     res
   }
 
+  override def updateTableInfo(tableInfo: AuditTableInfo): Try[AuditTable] =
+    storageOps.writeAuditTableInfo(baseFolder, tableInfo)
+    .map(info => new AuditTableFile(info, regions, storageOps, baseFolder, newRegionID))
+
   override def allBetween(from: Option[Timestamp], to: Option[Timestamp]): Option[Dataset[_]] = {
     val regionIDs = activeRegionIDs()
     regionIDs.flatMap { ids =>

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
@@ -62,6 +62,9 @@ object StorageActions extends Logging {
   val RECOMPACT_ALL = s"$storageParamPrefix.recompactAll"
   val RECOMPACT_ALL_DEFAULT = false
 
+  /**
+    * Whether to update the metadata (call the metadata retrieval function and persist the result) for existing tables
+    */
   val UPDATE_TABLE_METADATA = s"$storageParamPrefix.updateMetadata"
   val UPDATE_TABLE_METADATA_DEFAULT = false
 

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
@@ -201,7 +201,7 @@ object StorageActions extends Logging {
       * @return a new SparkDataFlow with the get action added
       */
     def getAuditTable(storageBasePath: String, labelPrefix: Option[String] = Some("audittable"), includeHot: Boolean = true)(tableNames: String*): SparkDataFlow = {
-
+      sparkDataFlow.flowContext.spark.conf.set(UPDATE_TABLE_METADATA, false)
       sparkDataFlow.getOrCreateAuditTable(storageBasePath, None, labelPrefix, includeHot)(tableNames: _*)
 
     }

--- a/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
+++ b/waimak-storage/src/main/scala/com/coxautodata/waimak/storage/StorageActions.scala
@@ -151,8 +151,12 @@ object StorageActions extends Logging {
 
         val (existingTables, missingTables) = Storage.openFileTables(sparkDataFlow.flowContext.spark, basePath, tableNames, includeHot)
 
-        if ((missingTables.nonEmpty || updateTableMetadata) && metadataRetrieval.isEmpty) {
+        if (missingTables.nonEmpty && metadataRetrieval.isEmpty) {
           throw StorageException(s"The following tables were not found in the storage layer and could not be created as no metadata function was defined: ${missingTables.mkString(",")}")
+        }
+
+        if (updateTableMetadata && metadataRetrieval.isEmpty) {
+          throw StorageException(s"$UPDATE_TABLE_METADATA is set to true but no metadata function was defined")
         }
 
         val existingTablesWithUpdatedMetadata = if (updateTableMetadata) {

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
@@ -90,6 +90,20 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
       infoData should be(Success(AuditTableInfo(tableName, Seq("id"), Map.empty, true)))
     }
 
+    it("init table then updated table info") {
+      val zeroState = createADTable(tableName, createFops())
+
+      val nextState = zeroState.initNewTable().get
+
+      val infoData = zeroState.storageOps.readAuditTableInfo(basePath, tableName)
+      infoData should be(Success(AuditTableInfo(tableName, Seq("id"), Map.empty, true)))
+
+      val updatedTableInfoState = nextState.updateTableInfo(AuditTableInfo(tableName, Seq("id1", "id2"), Map.empty, false))
+
+      val updatedInfoData = zeroState.storageOps.readAuditTableInfo(basePath, tableName)
+      updatedInfoData should be(Success(AuditTableInfo(tableName, Seq("id1", "id2"), Map.empty, false)))
+    }
+
     it("init table fail") {
       val zeroState = createADTable(tableName, createFops())
 

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestAuditTableFile.scala
@@ -90,7 +90,7 @@ class TestAuditTableFile extends SparkAndTmpDirSpec {
       infoData should be(Success(AuditTableInfo(tableName, Seq("id"), Map.empty, true)))
     }
 
-    it("init table then updated table info") {
+    it("init table then update table info") {
       val zeroState = createADTable(tableName, createFops())
 
       val nextState = zeroState.initNewTable().get

--- a/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
+++ b/waimak-storage/src/test/scala/com/coxautodata/waimak/storage/TestStorageActions.scala
@@ -173,7 +173,12 @@ class TestStorageActions extends SparkAndTmpDirSpec {
       //update metadata
       spark.conf.set(UPDATE_TABLE_METADATA, true)
       val res3 = executor.execute(flow2)
-      res3._2.inputs.get[AuditTableFile]("audittable_t_record").tableInfo should be(AuditTableInfo("t_record", Seq("id1","id2"), Map.empty, false))
+      res3._2.inputs.get[AuditTableFile]("audittable_t_record").tableInfo should be(AuditTableInfo("t_record", Seq("id1", "id2"), Map.empty, false))
+
+      //Check new metadata has been persisted
+      spark.conf.set(UPDATE_TABLE_METADATA, false)
+      val res4 = executor.execute(flow1)
+      res4._2.inputs.get[AuditTableFile]("audittable_t_record").tableInfo should be(AuditTableInfo("t_record", Seq("id1", "id2"), Map.empty, false))
 
     }
   }


### PR DESCRIPTION
# Description

Currently, once a table is created in the storage layer, there is no way of programmatically updating its metadata. This PR introduces a flag, `spark.waimak.storage.updateMetadata`, which will force metadata retrieval for all tables and persist the new metadata.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Additional unit tests