### PR TITLE
Clean up temporary folder by default after flow execution

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
@@ -411,6 +411,15 @@ trait DataFlow extends Logging {
   }
 
   /**
+    * A function called just after the flow is executed.
+    * By default, the implementation on [[DataFlow]] is no-op,
+    * however it is used in [[spark.SparkDataFlow]] to clean up
+    * the temporary directory
+    *
+    */
+  def finaliseExecution(): Try[this.type] = Success(this)
+
+  /**
     * Flow DAG is valid iff:
     * 1. All output labels and existing input labels unique
     * 2. Each action depends on labels that are produced by actions or already present in inputs

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestParquetDataCommitter.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestParquetDataCommitter.scala
@@ -206,6 +206,7 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
       it("commit a repartitioned parquet and make sure one label is cached if it is used as input elsewhere") {
         val spark = sparkSession
         import spark.implicits._
+        spark.conf.set(SparkDataFlow.REMOVE_TEMP_AFTER_EXECUTION, false)
 
         val baseDest = testingBaseDir + "/dest"
 
@@ -230,6 +231,7 @@ class TestParquetDataCommitter extends SparkAndTmpDirSpec {
       it("commit a repartitioned parquet and make sure one label is not cached if it is not used as input elsewhere") {
         val spark = sparkSession
         import spark.implicits._
+        spark.conf.set(SparkDataFlow.REMOVE_TEMP_AFTER_EXECUTION, false)
 
         val baseDest = testingBaseDir + "/dest"
 

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkInterceptors.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkInterceptors.scala
@@ -40,6 +40,7 @@ class TestSparkInterceptors extends SparkAndTmpDirSpec {
     it("snapshot") {
       val spark = sparkSession
       import spark.implicits._
+      spark.conf.set(SparkDataFlow.REMOVE_TEMP_AFTER_EXECUTION, false)
 
       val flow = Waimak.sparkFlow(sparkSession, tmpDir.toString)
         .openCSV(basePath)("csv_1")
@@ -64,6 +65,7 @@ class TestSparkInterceptors extends SparkAndTmpDirSpec {
     it("combine post and snapshot") {
       val spark = sparkSession
       import spark.implicits._
+      spark.conf.set(SparkDataFlow.REMOVE_TEMP_AFTER_EXECUTION, false)
 
       val flow = Waimak.sparkFlow(sparkSession, tmpDir.toString)
         .openCSV(basePath)("csv_1")


### PR DESCRIPTION
# Description

This PR introduces behaviour to clean up the temporary folder (if given) after a flow has been executed.

This behaviour can be disabled by setting the configuration property `spark.waimak.dataflow.removeTempAfterExecution` to false.

In all cases, the folder will not be deleted if flow execution fails.

Fixes #70 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests

Requires docs change