### PR TITLE
Issue 75 - Configurable Spark prefix in case class configuration parser

### DIFF
--- a/waimak-experimental/src/main/scala/com/coxautodata/waimak/spark/app/EnvironmentManager.scala
+++ b/waimak-experimental/src/main/scala/com/coxautodata/waimak/spark/app/EnvironmentManager.scala
@@ -24,11 +24,11 @@ object EnvironmentManager {
   }
 
   def performEnvironmentAction(sparkSession: SparkSession): Unit = {
-    val environmentAction = CaseClassConfigParser[EnvironmentAction](SparkFlowContext(sparkSession), "spark.waimak.environment.")
+    val environmentAction = CaseClassConfigParser[EnvironmentAction](SparkFlowContext(sparkSession), "waimak.environment.")
     val app = MultiAppRunner.instantiateApp(environmentAction.appClassName)
     environmentAction.action.toLowerCase() match {
-      case "create" => app.createEnv(sparkSession, "spark.waimak.environment.")
-      case "cleanup" => app.cleanupEnv(sparkSession, "spark.waimak.environment.")
+      case "create" => app.createEnv(sparkSession, "waimak.environment.")
+      case "cleanup" => app.cleanupEnv(sparkSession, "waimak.environment.")
       case _ => throw new UnsupportedOperationException(s"Unsupported environment action: ${environmentAction.action}")
     }
   }

--- a/waimak-experimental/src/main/scala/com/coxautodata/waimak/spark/app/MultiAppRunner.scala
+++ b/waimak-experimental/src/main/scala/com/coxautodata/waimak/spark/app/MultiAppRunner.scala
@@ -47,9 +47,9 @@ object MultiAppRunner {
   }
 
   def runAll(sparkSession: SparkSession): Unit = {
-    val allApps = CaseClassConfigParser[AllApps](SparkFlowContext(sparkSession), "spark.waimak.apprunner.")
+    val allApps = CaseClassConfigParser[AllApps](SparkFlowContext(sparkSession), "waimak.apprunner.")
     val allAppsConfig = allApps.apps.map(appName => appName ->
-      CaseClassConfigParser[SingleAppConfig](SparkFlowContext(sparkSession), s"spark.waimak.apprunner.$appName."))
+      CaseClassConfigParser[SingleAppConfig](SparkFlowContext(sparkSession), s"waimak.apprunner.$appName."))
     val executor = Waimak.sparkExecutor()
     val finalFlow = allAppsConfig.foldLeft(Waimak.sparkFlow(sparkSession))((flow, appConfig) => addAppToFlow(flow, appConfig._1, appConfig._2))
     executor.execute(finalFlow)
@@ -64,7 +64,7 @@ object MultiAppRunner {
   def addAppToFlow(flow: SparkDataFlow, appName: String, appConfig: SingleAppConfig): SparkDataFlow = {
     val instantiatedApp = instantiateApp(appConfig.appClassName)
     flow.executeApp(appConfig.dependencies: _*)(
-      instantiatedApp.runSparkApp(_, s"spark.waimak.environment.$appName."), appName)
+      instantiatedApp.runSparkApp(_, s"waimak.environment.$appName."), appName)
   }
 
 }

--- a/waimak-experimental/src/main/scala/com/coxautodata/waimak/spark/app/SparkApp.scala
+++ b/waimak-experimental/src/main/scala/com/coxautodata/waimak/spark/app/SparkApp.scala
@@ -1,6 +1,7 @@
 package com.coxautodata.waimak.spark.app
 
 import com.coxautodata.waimak.configuration.CaseClassConfigParser
+import com.coxautodata.waimak.dataflow.spark.SparkFlowContext
 import org.apache.spark.sql.SparkSession
 
 import scala.reflect.runtime.universe.TypeTag
@@ -69,7 +70,7 @@ abstract class SparkApp[E <: Env : TypeTag] {
     * @param envPrefix    the prefix for keys in the SparkConf needed by the [[Env]] implementation
     * @return a parsed case class of type [[E]]
     */
-  def parseEnv(sparkSession: SparkSession, envPrefix: String): E = CaseClassConfigParser.fromMap[E](sparkSession.conf.getAll, envPrefix)
+  def parseEnv(sparkSession: SparkSession, envPrefix: String): E = CaseClassConfigParser(SparkFlowContext(sparkSession), envPrefix)
 
   /**
     * Default Spark configuration values to use for the application


### PR DESCRIPTION
# Description

This PR changes the case class configuration parser to make the `spark.` prefix configurable only when looking for parameters in the SparkConf on the session.

For example:
Given a case class: `case class Test(a: String)`
And config property: `spark.configgroup.project1.a=b`

It would be nice to set a waimak parameter for the SparkConf part of config parsing to use a prefix when retrieving config from the SparkSession conf.

By default, it is:
```scala
val SPARK_CONF_PREFIX: String = s"$configParamPrefix.sparkConfPropertyPrefix"
val SPARK_CONF_PREFIX_DEFAULT: String = "spark."
```

So you would parse the config like:
`CaseClassConfigParser[Test](sparkFlowContext, "configgroup.project1"))`

When looking in the spark conf, it will add the spark. config to the prefix. This has the benefit that when using other property providers (like Databricks Secrets), the config keys don't need to be prefixed by spark. They would be found like: configgroup.project1.a.

This also adds an optional Map you can pass in where the parser will look for additional parameter values

Fixes #75 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unit tests and running in dev

**Note: This is a breaking change as existing calls to the case class parse will fail as the `spark.` prefix must be removed**