### PR TITLE
Feature/issue 74 execute action

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
@@ -32,10 +32,22 @@ trait DataFlow extends Logging {
 
   def commitMeta(cm: CommitMeta): this.type
 
+  /**
+    * Current [[DataFlowExecutor]] associated with this flow
+    * @return
+    */
   def executor: DataFlowExecutor
 
+  /**
+    * Add a new executor to this flow, replacing the existing one
+    * @param executor [[DataFlowExecutor]] to add to this flow
+    */
   def withExecutor(executor: DataFlowExecutor): this.type
 
+  /**
+    * Execute this flow using the current [[executor]] on the flow.
+    * See [[DataFlowExecutor.execute()]] for more information.
+    */
   def execute(errorOnUnexecutedActions: Boolean = true): (Seq[DataFlowAction], DataFlow) = executor.execute(this, errorOnUnexecutedActions)
 
   /**

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/DataFlow.scala
@@ -32,6 +32,12 @@ trait DataFlow extends Logging {
 
   def commitMeta(cm: CommitMeta): this.type
 
+  def executor: DataFlowExecutor
+
+  def withExecutor(executor: DataFlowExecutor): this.type
+
+  def execute(errorOnUnexecutedActions: Boolean = true): (Seq[DataFlowAction], DataFlow) = executor.execute(this, errorOnUnexecutedActions)
+
   /**
     * Inputs that were explicitly set or produced by previous actions, these are inputs for all following actions.
     * Inputs are preserved in the data flow state, even if they are no longer required by the remaining actions.

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkDataFlow.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/SparkDataFlow.scala
@@ -117,6 +117,9 @@ class SparkDataFlow(info: SparkDataFlowInfo) extends DataFlow with Logging {
       }
   }
 
+  override def executor: DataFlowExecutor = info.executor
+
+  override def withExecutor(executor: DataFlowExecutor): this.type = new SparkDataFlow(info.copy(executor = executor)).asInstanceOf[this.type]
 }
 
 case class LabelCommitDefinition(basePath: String, timestampFolder: Option[String] = None, partitions: Seq[String] = Seq.empty, connection: Option[HadoopDBConnector] = None)
@@ -181,7 +184,8 @@ case class SparkDataFlowInfo(spark: SparkSession,
                              schedulingMeta: SchedulingMeta,
                              commitLabels: Map[String, LabelCommitDefinition] = Map.empty,
                              tagState: DataFlowTagState = DataFlowTagState(Set.empty, Set.empty, Map.empty),
-                             commitMeta: CommitMeta = CommitMeta.empty)
+                             commitMeta: CommitMeta = CommitMeta.empty,
+                             executor: DataFlowExecutor = Waimak.sparkExecutor())
 
 object SparkDataFlow {
 

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/MockDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/MockDataFlow.scala
@@ -8,7 +8,8 @@ case class MockDataFlow(flowContext: FlowContext
                        , commitMeta: CommitMeta
                        , inputs: DataFlowEntities
                        , actions: Seq[DataFlowAction]
-                       , tagState: DataFlowTagState) extends DataFlow {
+                       , tagState: DataFlowTagState
+                       , executor: DataFlowExecutor) extends DataFlow {
 
 
   override def schedulingMeta(sc: SchedulingMeta): MockDataFlow.this.type = this.copy(schedulingMeta = sc).asInstanceOf[this.type]
@@ -21,10 +22,11 @@ case class MockDataFlow(flowContext: FlowContext
 
   override def tagState(ts: DataFlowTagState): MockDataFlow.this.type = this.copy(tagState = ts).asInstanceOf[this.type]
 
+  override def withExecutor(executor: DataFlowExecutor): MockDataFlow.this.type = this.copy(executor = executor).asInstanceOf[this.type]
 }
 
 object MockDataFlow {
 
-  def empty: MockDataFlow = MockDataFlow(new EmptyFlowContext, new SchedulingMeta(), CommitMeta(Map.empty, Map.empty), DataFlowEntities.empty, Seq.empty, DataFlowTagState(Set.empty, Set.empty, Map.empty))
+  def empty: MockDataFlow = MockDataFlow(new EmptyFlowContext, new SchedulingMeta(), CommitMeta(Map.empty, Map.empty), DataFlowEntities.empty, Seq.empty, DataFlowTagState(Set.empty, Set.empty, Map.empty), SequentialDataFlowExecutor(NoReportingFlowReporter.apply()))
 
 }

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestSequentialDataFlowExecutorNonSpark.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestSequentialDataFlowExecutorNonSpark.scala
@@ -214,6 +214,34 @@ class TestSequentialDataFlowExecutorNonSpark extends FunSpec with Matchers {
 
       }
     }
+
+    describe("executing a flow inline") {
+      it("should execute a simple flow") {
+        val action_1 = new TestPresetAction(List.empty, List("t1", "t2"), func2)
+        val action_2 = new TestPresetAction(List.empty, List("t3", "t4"), func2)
+        val res = emptyFlow.addAction(action_1).addAction(action_2).execute()
+
+        res._1 should be(Seq(action_1, action_2))
+        res._2.inputs should be(DataFlowEntities(Map("t1" -> Some("v1"), "t2" -> Some("v2"), "t3" -> Some("v1"), "t4" -> Some("v2"))))
+        res._2.actions should be(Seq.empty)
+      }
+
+      it("should add a new executor to a flow") {
+        val action_1 = new TestPresetAction(List.empty, List("t1", "t2"), func2)
+        val action_2 = new TestPresetAction(List.empty, List("t3", "t4"), func2)
+        val reporter = new TestReporter
+        val executor = SequentialDataFlowExecutor(reporter)
+        val res = emptyFlow.withExecutor(executor).addAction(action_1).addAction(action_2).execute()
+
+        res._1 should be(Seq(action_1, action_2))
+        res._2.inputs should be(DataFlowEntities(Map("t1" -> Some("v1"), "t2" -> Some("v2"), "t3" -> Some("v1"), "t4" -> Some("v2"))))
+        res._2.actions should be(Seq.empty)
+
+        reporter.reports.length should be (4)
+
+      }
+
+    }
   }
 }
 

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
@@ -184,6 +184,28 @@ class TestSparkDataFlow extends SparkAndTmpDirSpec {
 
   }
 
+  describe("execute") {
+    it("execute a flow inline") {
+      val spark = sparkSession
+      import spark.implicits._
+
+      val (executedActions, finalState) = Waimak.sparkFlow(spark)
+        .openCSV(basePath)("csv_1", "csv_2")
+        .show("csv_1")
+        .show("csv_2")
+        .execute()
+
+      //validate executed actions
+      executedActions.size should be(4)
+      executedActions.map(a => a.description) should be(Seq("Action: read Inputs: [] Outputs: [csv_1]", "Action: read Inputs: [] Outputs: [csv_2]", "Action: show Inputs: [csv_1] Outputs: []", "Action: show Inputs: [csv_2] Outputs: []"))
+
+      finalState.actions.size should be(0) // no actions to execute
+      finalState.inputs.size should be(2)
+      finalState.inputs.getOption[Dataset[_]]("csv_1").map(_.as[TPurchase].collect()).get should be(purchases)
+      finalState.inputs.getOption[Dataset[_]]("csv_2").map(_.as[TPerson].collect()).get should be(persons)
+    }
+  }
+
   describe("sql") {
 
     it("group by single") {

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
@@ -193,6 +193,7 @@ class TestSparkDataFlow extends SparkAndTmpDirSpec {
         .openCSV(basePath)("csv_1", "csv_2")
         .show("csv_1")
         .show("csv_2")
+        .withExecutor(executor)
         .execute()
 
       //validate executed actions


### PR DESCRIPTION
# Description

This adds `withExecutor` and `execute` functions onto DataFlows allowing DataFlows to be executed inline without needing to create an Executor explicitly and call execute.

Fixes #74 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests