### PR TITLE
Fix for parallel scheduler hanging on certain types of exceptions

### DIFF
--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestParallelDataFlowExecutorNonSpark.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestParallelDataFlowExecutorNonSpark.scala
@@ -1,0 +1,33 @@
+package com.coxautodata.waimak.dataflow
+
+import com.coxautodata.waimak.dataflow.DFExecutorPriorityStrategies._
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.util.Try
+
+class TestParallelDataFlowExecutorNonSpark extends FunSpec with Matchers {
+
+  val exceptionAction = new DataFlowAction {
+    override val inputLabels: List[String] = List.empty
+    override val outputLabels: List[String] = List.empty
+
+    override def performAction[C <: FlowContext](inputs: DataFlowEntities, flowContext: C): Try[ActionResult] = Try {
+      /**
+        * Any Fatal exception as defined in [[scala.util.control.NonFatal]]
+        */
+      throw new NoClassDefFoundError("Test Exception")
+    }
+  }
+
+  val emptyFlow = MockDataFlow.empty
+
+  val executor = new ParallelDataFlowExecutor(ParallelActionScheduler(), NoReportingFlowReporter(), defaultPriorityStrategy)
+
+  describe("execute") {
+
+    it("non-recoverable exception in action") {
+      executor.execute(emptyFlow.addAction(exceptionAction))
+    }
+
+  }
+}

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestParallelDataFlowExecutorNonSpark.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/TestParallelDataFlowExecutorNonSpark.scala
@@ -26,7 +26,13 @@ class TestParallelDataFlowExecutorNonSpark extends FunSpec with Matchers {
   describe("execute") {
 
     it("non-recoverable exception in action") {
-      executor.execute(emptyFlow.addAction(exceptionAction))
+
+      val res = intercept[DataFlowException] {
+        executor.execute(emptyFlow.addAction(exceptionAction))
+      }
+      res.cause shouldBe a[DataFlowException]
+
+      res.cause.asInstanceOf[DataFlowException].cause shouldBe a[NoClassDefFoundError]
     }
 
   }


### PR DESCRIPTION
# Description
Rework handling of exceptions to take into account fatal exceptions.
This fixes the issue of some types of exceptions causing flows to hang indefinitely.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests