### PR TITLE
Feature/multiple environments in environment action

### DIFF
--- a/waimak-app/src/main/scala/com/coxautodata/waimak/spark/app/EnvironmentManager.scala
+++ b/waimak-app/src/main/scala/com/coxautodata/waimak/spark/app/EnvironmentManager.scala
@@ -10,9 +10,9 @@ import org.apache.spark.sql.SparkSession
   *
   * spark.waimak.environment.ids: comma-separated unique ids for the environments
   * spark.waimak.environment.{environmentid}.appClassName: the application class to use (must extend [[SparkApp]])
-  * spark.waimak.environment.{environmentid}.action: the environment action to perform (create or cleanup)
+  * spark.waimak.environment.action: the environment action to perform (create or cleanup)
   *
-  * The [[Env]] implementation expects configuration values prefixed with spark.waimak.environment.
+  * The [[Env]] implementation expects configuration values prefixed with spark.waimak.environment.{environmentid}.
   */
 object EnvironmentManager {
 

--- a/waimak-app/src/test/scala/com/coxautodata/waimak/spark/app/TestEnvironmentManager.scala
+++ b/waimak-app/src/test/scala/com/coxautodata/waimak/spark/app/TestEnvironmentManager.scala
@@ -9,12 +9,13 @@ class TestEnvironmentManager extends AppRunnerSpec {
   describe("performEnvironmentAction") {
     it("should create a Hive environment") {
       sparkSession = buildSparkSession(Map(
-        "spark.waimak.environment.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
+        "spark.waimak.environment.ids" -> "1"
+        , "spark.waimak.environment.1.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
         , "spark.waimak.environment.action" -> "create"
-        , "spark.waimak.environment.project" -> "app_1"
-        , "spark.waimak.environment.environment" -> "dev"
-        , "spark.waimak.environment.branch" -> "feature/test-multi-app-runner"
-        , "spark.waimak.environment.uri" -> testingBaseDirName
+        , "spark.waimak.environment.1.project" -> "app_1"
+        , "spark.waimak.environment.1.environment" -> "dev"
+        , "spark.waimak.environment.1.branch" -> "feature/test-multi-app-runner"
+        , "spark.waimak.environment.1.uri" -> testingBaseDirName
       ))
       val fs = FileSystem.get(sparkSession.sparkContext.hadoopConfiguration)
       val basePath = s"$testingBaseDirName/data/dev/app_1/feature_test_multi_app_runner"
@@ -28,12 +29,13 @@ class TestEnvironmentManager extends AppRunnerSpec {
 
     it("should cleanup a Hive environment") {
       sparkSession = buildSparkSession(Map(
-        "spark.waimak.environment.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
+        "spark.waimak.environment.ids" -> "1"
+        , "spark.waimak.environment.1.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
         , "spark.waimak.environment.action" -> "cleanup"
-        , "spark.waimak.environment.project" -> "app_1"
-        , "spark.waimak.environment.environment" -> "dev"
-        , "spark.waimak.environment.branch" -> "feature/test-multi-app-runner"
-        , "spark.waimak.environment.uri" -> testingBaseDirName
+        , "spark.waimak.environment.1.project" -> "app_1"
+        , "spark.waimak.environment.1.environment" -> "dev"
+        , "spark.waimak.environment.1.branch" -> "feature/test-multi-app-runner"
+        , "spark.waimak.environment.1.uri" -> testingBaseDirName
       ))
       val fs = FileSystem.get(sparkSession.sparkContext.hadoopConfiguration)
       val basePath = s"$testingBaseDirName/data/dev/app_1/feature_test_multi_app_runner"
@@ -49,15 +51,47 @@ class TestEnvironmentManager extends AppRunnerSpec {
 
     it("should throw an UnsupportedOperationException if the action is neither create nor cleanup") {
       sparkSession = buildSparkSession(Map(
-        "spark.waimak.environment.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
+        "spark.waimak.environment.ids" -> "1"
+        , "spark.waimak.environment.1.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
         , "spark.waimak.environment.action" -> "not-a-real-environment-action"
-        , "spark.waimak.environment.project" -> "app_1"
-        , "spark.waimak.environment.environment" -> "dev"
-        , "spark.waimak.environment.branch" -> "feature/test-multi-app-runner"
-        , "spark.waimak.environment.uri" -> testingBaseDirName
+        , "spark.waimak.environment.1.project" -> "app_1"
+        , "spark.waimak.environment.1.environment" -> "dev"
+        , "spark.waimak.environment.1.branch" -> "feature/test-multi-app-runner"
+        , "spark.waimak.environment.1.uri" -> testingBaseDirName
       ))
       val err = intercept[UnsupportedOperationException](EnvironmentManager.performEnvironmentAction(sparkSession))
       err.getMessage should be("Unsupported environment action: not-a-real-environment-action")
+    }
+
+    it("should perform environment actions on multiple environments") {
+      sparkSession = buildSparkSession(Map(
+        "spark.waimak.environment.ids" -> "1,2"
+        , "spark.waimak.environment.action" -> "create"
+        , "spark.waimak.environment.1.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
+        , "spark.waimak.environment.1.project" -> "app_1"
+        , "spark.waimak.environment.1.environment" -> "dev"
+        , "spark.waimak.environment.1.branch" -> "feature/test-multi-app-runner"
+        , "spark.waimak.environment.1.uri" -> testingBaseDirName
+        , "spark.waimak.environment.2.appClassName" -> "com.coxautodata.waimak.spark.app.WaimakAppWithNoDependency"
+        , "spark.waimak.environment.2.project" -> "app_2"
+        , "spark.waimak.environment.2.environment" -> "dev"
+        , "spark.waimak.environment.2.branch" -> "feature/test-multi-app-runner"
+        , "spark.waimak.environment.2.uri" -> testingBaseDirName
+      ))
+      val fs = FileSystem.get(sparkSession.sparkContext.hadoopConfiguration)
+      val basePath1 = s"$testingBaseDirName/data/dev/app_1/feature_test_multi_app_runner"
+      val basePath2 = s"$testingBaseDirName/data/dev/app_2/feature_test_multi_app_runner"
+      val dbName1 = "dev_app_1_feature_test_multi_app_runner"
+      val dbName2 = "dev_app_2_feature_test_multi_app_runner"
+      fs.exists(new Path(basePath1)) should be(false)
+      fs.exists(new Path(basePath2)) should be(false)
+      sparkSession.catalog.databaseExists(dbName1) should be(false)
+      sparkSession.catalog.databaseExists(dbName2) should be(false)
+      EnvironmentManager.performEnvironmentAction(sparkSession)
+      fs.exists(new Path(basePath1)) should be(true)
+      fs.exists(new Path(basePath2)) should be(true)
+      sparkSession.catalog.databaseExists(dbName1) should be(true)
+      sparkSession.catalog.databaseExists(dbName2) should be(true)
     }
   }
 }


### PR DESCRIPTION
# Description

Can now create or cleanup multiple environments at once in the `EnvironmentManager`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
