### PR TITLE
Create directory before doing move in writeAsNamedFiles

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/WriteAsNamedFilesAction.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/WriteAsNamedFilesAction.scala
@@ -39,6 +39,7 @@ case class WriteAsNamedFilesAction(label: String, tempBasePath: Path, destBasePa
       }
       .foreach {
         case (sourceFile, number) =>
+          flowContext.fileSystem.mkdirs(destBasePath)
           val destPath = new Path(destBasePath, s"${filenamePrefix}${number}${getOutputExtension(sourceFile.getPath)}")
           if (!flowContext.fileSystem.rename(sourceFile.getPath, destPath)) throw new DataFlowException(s"Failed to move file [${sourceFile.getPath}] to [$destPath]")
       }


### PR DESCRIPTION
# Description

`writeAsNamedFiles` will now create the output directory before performing the move from the tmp directory. This means that for filesystems which don't create the destination directory on `rename`, the action works as expected.

Fixes #95 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unfortunately, I couldn't recreate the issue in a unit test as this doesn't seem to be an issue using the local file system (the directory gets created on `rename`). The issue was originally seen when using ADLS, and I've tested this version with ADLS and it works as expected.
