### PR TITLE
Changed delimiter for Deequ genericSQLCheck

### DIFF
--- a/waimak-deequ/src/main/scala/com/coxautodata/waimak/dataflow/spark/dataquality/deequ/prefabchecks/GenericSQLCheck.scala
+++ b/waimak-deequ/src/main/scala/com/coxautodata/waimak/dataflow/spark/dataquality/deequ/prefabchecks/GenericSQLCheck.scala
@@ -2,6 +2,7 @@ package com.coxautodata.waimak.dataflow.spark.dataquality.deequ.prefabchecks
 
 import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.{VerificationRunBuilder, VerificationRunBuilderWithRepository}
+import com.coxautodata.waimak.configuration.CaseClassConfigParser.separator
 import com.coxautodata.waimak.dataflow.spark.dataquality.deequ.DeequPrefabCheck
 
 /**
@@ -26,4 +27,5 @@ class GenericSQLCheck extends DeequPrefabCheck[GenericSQLCheckConfig] {
   override def checkName: String = "genericSQLCheck"
 }
 
-case class GenericSQLCheckConfig(warningChecks: Seq[String] = Nil, criticalChecks: Seq[String] = Nil)
+case class GenericSQLCheckConfig(@separator(";") warningChecks: Seq[String] = Nil
+                                 , @separator(";") criticalChecks: Seq[String] = Nil)


### PR DESCRIPTION
# Description

Delimiter for the Deequ `genericSQLCheck` has been changed from a comma to a semicolon to allow for checks which include commas (such as `col_a in ('abc', 'def')`)

This is a breaking change as existing comma-delimited config will no longer work.

Fixes #97 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Additional unit test covering this scenario
