### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <docker.maven.plugin.version>0.25.2</docker.maven.plugin.version>
         <scala.maven.plugin.version>3.2.2</scala.maven.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
-        <scalatest.maven.plugin.version>1.0</scalatest.maven.plugin.version>
+        <scalatest.maven.plugin.version>2.0.0</scalatest.maven.plugin.version>
         <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <jgitflow.maven.plugin.version>1.0-m5.1</jgitflow.maven.plugin.version>


### PR DESCRIPTION
Scalatest 1.0 does not work well on windows see bug https://github.com/scalatest/scalatest-maven-plugin/pull/24 upgrade to 2.0 worked for me. Just for your information

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you have included to verify your changes
