### PR TITLE
Make sql server extract from historic tables using a single query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,11 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>${basedir}/src/main/scala</sourceDirectory>

--- a/waimak-core/pom.xml
+++ b/waimak-core/pom.xml
@@ -33,6 +33,11 @@
             <version>${scala.lang.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.beachape</groupId>
+            <artifactId>enumeratum_2.11</artifactId>
+            <version>1.5.15</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/waimak-core/src/main/scala/com/coxautodata/waimak/log/Logging.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/log/Logging.scala
@@ -1,11 +1,28 @@
 package com.coxautodata.waimak.log
 
 import org.slf4j.{Logger, LoggerFactory}
+import enumeratum._
+import scala.collection.immutable
+import scala.util.{Failure, Success, Try}
+
+sealed trait Level extends EnumEntry
+
+object Level extends Enum[Level] {
+  override def values: immutable.IndexedSeq[Level] = findValues
+
+  case object Info extends Level
+  case object Debug extends Level
+  case object Trace extends Level
+  case object Warning extends Level
+  case object Error extends Level
+}
 
 /**
   * Created by Vicky Avison on 05/06/17.
   */
 trait Logging {
+
+  import Level._
 
   // Method to get the logger name for this object
   protected def logName: String = {
@@ -61,5 +78,45 @@ trait Logging {
     log.isTraceEnabled
   }
 
+  /**
+   * Takes a value of type A and a function message from A to String, logs the value of
+   * invoking message(a) at the level described by the level parameter
+   *
+   * @example {{{
+   *           logAndReturn(1, (num: Int) => s"number: $num", Info)
+   *           // In the log we would see a log corresponding to "number 1"
+   * }}}
+   *
+   * @param a
+   * @param message
+   * @param level
+   * @tparam A
+   * @return a
+   */
+  def logAndReturn[A](a: A, message: A => String, level: Level): A =
+    Try(message(a)) match {
+      case Success(msg) => logAndReturn(a, msg, level)
+      case Failure(exception) => logError("logAndReturn message function threw an exception"); exception.printStackTrace(); a
+    }
 
+  /**
+   * Takes a value of type A and a msg to log, returning a and logging the message at the desired level
+   *
+   * @param a
+   * @param msg
+   * @param level
+   * @tparam A
+   * @return a
+   */
+  def logAndReturn[A](a: A, msg: String, level: Level): A = {
+    level match {
+      case Info => logInfo(msg)
+      case Debug => logDebug(msg)
+      case Trace => logTrace(msg)
+      case Warning => logWarning(msg)
+      case Error => logError(msg)
+    }
+
+    a
+  }
 }

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/SparkSpec.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/SparkSpec.scala
@@ -3,6 +3,7 @@ package com.coxautodata.waimak.dataflow.spark
 import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
+import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
@@ -16,7 +17,19 @@ trait SparkSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   val master = "local[2]"
   val appName: String
 
-  def builderOptions: SparkSession.Builder => SparkSession.Builder = identity
+  /**
+   * Allows configuring spark session options. Override this in your own tests to set any
+   * config options you might wish to add. This default implementation also detects if you are
+   * running the tests on windows, and sets the bindAddress option to make the tests work.
+   *
+   * @see com.coxautodata.waimak.metastore.TestHiveDBConnector for an example
+   *
+   * @return a spark session
+   */
+  def builderOptions: SparkSession.Builder => SparkSession.Builder = { sparkSession =>
+    if (SystemUtils.IS_OS_WINDOWS) sparkSession.config("spark.driver.bindAddress", "localhost")
+    else sparkSession
+  }
 
   override def beforeEach(): Unit = {
     val preBuilder = SparkSession

--- a/waimak-hive/src/test/scala/com/coxautodata/waimak/metastore/TestHiveDBConnector.scala
+++ b/waimak-hive/src/test/scala/com/coxautodata/waimak/metastore/TestHiveDBConnector.scala
@@ -12,9 +12,11 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 class TestHiveDBConnector extends SparkAndTmpDirSpec {
 
   override def builderOptions: SparkSession.Builder => SparkSession.Builder = {
-    _.enableHiveSupport()
+    val build = (sparkSession: SparkSession.Builder) => sparkSession.enableHiveSupport()
       .config("spark.sql.warehouse.dir", s"$basePath/hive")
       .config("javax.jdo.option.ConnectionURL", s"jdbc:derby:memory:;databaseName=$basePath/derby;create=true")
+
+    super.builderOptions andThen build
   }
 
   override val appName: String = "Metastore Utils"

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/ExtractionMetadata.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/ExtractionMetadata.scala
@@ -1,0 +1,60 @@
+package com.coxautodata.waimak.rdbm.ingestion
+
+trait ExtractionMetadata {
+  def schemaName: String
+  def tableName: String
+  def primaryKeys: String
+  def pks: Seq[String]
+  def lastUpdatedColumn: Option[String]
+  def qualifiedTableName(escapeKeyword: String => String): String
+  def labelName: String = s"${schemaName}_$tableName"
+  def transformTableName(transform: String => String): ExtractionMetadata
+
+  // Fit with temporal metadata
+  def historyTableSchema: Option[String] = None
+  def historyTableName: Option[String] = None
+  def startColName: Option[String] = None
+  def endColName: Option[String] = None
+}
+
+case class TableExtractionMetadata( schemaName: String
+                                    , tableName: String
+                                    , pks: Seq[String]
+                                    , lastUpdatedColumn: Option[String] = None) extends ExtractionMetadata {
+  def qualifiedTableName(escapeKeyword: String => String): String =
+    s"${escapeKeyword(schemaName)}.${escapeKeyword(tableName)}"
+
+  override def transformTableName(transform: String => String): ExtractionMetadata = this.copy(tableName = transform(tableName))
+
+  override def primaryKeys: String = pks.mkString(";")
+}
+
+case class SQLServerTemporalTableMetadata(schemaName: String
+                                          , tableName: String
+                                          , override val historyTableSchema: Option[String] = None
+                                          , override val historyTableName: Option[String] = None
+                                          , override val startColName: Option[String] = None
+                                          , override val endColName: Option[String] = None
+                                          , primaryKeys: String) extends ExtractionMetadata {
+
+  def pkCols: Seq[String] =
+    if (primaryKeys.contains(";")) primaryKeys.split(";").toSeq
+    else Seq(primaryKeys)
+
+  def mainTableMetadata: TableExtractionMetadata = TableExtractionMetadata(schemaName, tableName, pkCols, startColName)
+
+  def isTemporal: Boolean = historyTableMetadata.isDefined
+
+  def historyTableMetadata: Option[TableExtractionMetadata] = for {
+    schema <- historyTableSchema
+    table <- historyTableName
+  } yield TableExtractionMetadata(schema, table, pkCols, endColName)
+
+  override def lastUpdatedColumn: Option[String] = startColName
+
+  override def qualifiedTableName(escapeKeyword: String => String): String = s"${escapeKeyword(schemaName)}.${escapeKeyword(tableName)}"
+
+  override def transformTableName(transform: String => String): ExtractionMetadata = this.copy(tableName = transform(tableName))
+
+  override def pks: Seq[String] = pkCols
+}

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
@@ -86,8 +86,8 @@ class PostgresExtractor(override val sparkSession: SparkSession
     allTablePKs.get(s"$dbSchemaName.$tableName").map(_.split(";").toSeq)
   }
 
-  override def loadDataset[A <: ExtractionMetadata](meta: Map[String, String], lastUpdated: Option[Timestamp], maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
-    super.loadDataset[TableExtractionMetadata](meta, lastUpdated, maxRowsPerPartition)
+  override def loadDataset(meta: Map[String, String], lastUpdated: Option[Timestamp], maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
+    super.loadDataset(meta, lastUpdated, maxRowsPerPartition)
   }
 
 }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
@@ -1,9 +1,11 @@
 package com.coxautodata.waimak.rdbm.ingestion
 
+import java.sql.Timestamp
 import java.util.Properties
 
+import com.coxautodata.waimak.configuration.CaseClassConfigParser
 import com.coxautodata.waimak.storage.AuditTableInfo
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Column, Dataset, SparkSession}
 
 import scala.util.{Failure, Success, Try}
 
@@ -72,16 +74,20 @@ class PostgresExtractor(override val sparkSession: SparkSession
     ((primaryKeys, getTablePKs(dbSchemaName, transformTableNameForRead(tableName))) match {
       case (Some(userPKs), Some(pksFromDB)) if userPKs.sorted != pksFromDB.sorted =>
         Failure(IncorrectUserPKException(userPKs, pksFromDB))
-      case (Some(userPKs), None) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
-      case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
+      case (Some(userPKs), None) => Success(TableExtractionMetadata.fromPkSeq(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
+      case (_, Some(pksFromDB)) => Success(TableExtractionMetadata.fromPkSeq(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
-    }).map(meta => AuditTableInfo(meta.tableName, meta.pks, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn)))
+    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeysSeq, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn)))
   }
 
 
   def getTablePKs(dbSchemaName: String
                   , tableName: String): Option[Seq[String]] = {
     allTablePKs.get(s"$dbSchemaName.$tableName").map(_.split(";").toSeq)
+  }
+
+  override def loadDataset[A <: ExtractionMetadata](meta: Map[String, String], lastUpdated: Option[Timestamp], maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
+    super.loadDataset[TableExtractionMetadata](meta, lastUpdated, maxRowsPerPartition)
   }
 
 }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/PostgresExtractor.scala
@@ -75,7 +75,7 @@ class PostgresExtractor(override val sparkSession: SparkSession
       case (Some(userPKs), None) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
       case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
-    }).map(meta => AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn)))
+    }).map(meta => AuditTableInfo(meta.tableName, meta.pks, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn)))
   }
 
 

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
@@ -4,15 +4,17 @@ import java.sql.Timestamp
 import java.util.Properties
 
 import com.coxautodata.waimak.configuration.CaseClassConfigParser
+import com.coxautodata.waimak.log.Level.{Debug, Info}
+import com.coxautodata.waimak.log.{Level, Logging}
 import com.coxautodata.waimak.storage.AuditTableInfo
-import org.apache.spark.sql.{Column, Dataset, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, SparkSession}
 
 import scala.util.Try
 
 /**
   * Waimak RDBM connection mechanism
   */
-trait RDBMExtractor {
+trait RDBMExtractor extends Logging {
 
   def connectionDetails: RDBMConnectionDetails
 
@@ -108,7 +110,7 @@ trait RDBMExtractor {
                                  , lastUpdatedColumn: Option[String]
                                  , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo]
 
-  def resolveLastUpdatedColumn(tableMetadata: TableExtractionMetadata, sparkSession: SparkSession): Column = {
+  def resolveLastUpdatedColumn(tableMetadata: ExtractionMetadata, sparkSession: SparkSession): Column = {
     import sparkSession.implicits._
     $"${tableMetadata.lastUpdatedColumn.getOrElse(systemTimestampColumnName)}"
   }
@@ -143,7 +145,7 @@ trait RDBMExtractor {
   protected def loadDataset(meta: Map[String, String]
                             , lastUpdated: Option[Timestamp]
                             , maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
-    val tableMetadata = CaseClassConfigParser.fromMap[TableExtractionMetadata](meta)
+    val tableMetadata = CaseClassConfigParser.fromMap[ExtractionMetadata](meta)
     (sparkLoad(tableMetadata, lastUpdated, maxRowsPerPartition), resolveLastUpdatedColumn(tableMetadata, sparkSession))
   }
 
@@ -180,15 +182,18 @@ trait RDBMExtractor {
     *                              select *) e.g. HIDDEN fields
     * @return a query which selects from the given table
     */
-  def selectQuery(tableMetadata: TableExtractionMetadata
+  def selectQuery(tableMetadata: ExtractionMetadata
                   , lastUpdated: Option[Timestamp]
                   , explicitColumnSelects: Seq[String]): String = {
     val extraSelectCols = (explicitColumnSelects :+ s"$sourceDBSystemTimestampFunction as $systemTimestampColumnName").mkString(",")
-    s"""(select *, $extraSelectCols ${fromQueryPart(tableMetadata, lastUpdated)}) s"""
+    logAndReturn(
+      s"""(select *, $extraSelectCols ${fromQueryPart(tableMetadata, lastUpdated)}) s""",
+      (query: String) => s"Query: $query for metadata ${tableMetadata.toString} for lastUpdated ${lastUpdated}",
+      Info
+    )
   }
 
-
-  protected def fromQueryPart(tableMetadata: TableExtractionMetadata
+  protected def fromQueryPart(tableMetadata: ExtractionMetadata
                               , lastUpdated: Option[Timestamp]): String = {
     (tableMetadata.lastUpdatedColumn, lastUpdated) match {
       case (Some(lastUpdatedCol), Some(ts)) =>
@@ -202,11 +207,11 @@ trait RDBMExtractor {
     *
     * @return a Spark Dataset for the table
     */
-  def sparkLoad(tableMetadata: TableExtractionMetadata
+  def sparkLoad(tableMetadata: ExtractionMetadata
                 , lastUpdated: Option[Timestamp]
                 , maxRowsPerPartition: Option[Int]
                 , explicitColumnSelects: Seq[String] = Seq.empty): Dataset[_] = {
-    val actualTableMetadata = tableMetadata.copy(tableName = transformTableNameForRead(tableMetadata.tableName))
+    val actualTableMetadata: ExtractionMetadata = tableMetadata.transformTableName(transformTableNameForRead)
     val select = selectQuery(actualTableMetadata, lastUpdated, explicitColumnSelects)
     maxRowsPerPartition.flatMap(maxRows => generateSplitPredicates(actualTableMetadata, lastUpdated, maxRows))
       .map(predicates => {
@@ -231,7 +236,7 @@ trait RDBMExtractor {
     * @return If the Dataset will have fewer rows than maxRowsPerParition then None, otherwise predicates to use
     *         in order to create the partitions e.g. "id >= 5 and id < 7"
     */
-  def generateSplitPredicates(tableMetadata: TableExtractionMetadata
+  def generateSplitPredicates(tableMetadata: ExtractionMetadata
                               , lastUpdated: Option[Timestamp]
                               , maxRowsPerPartition: Int): Option[Array[String]] = {
     val spark = sparkSession
@@ -246,23 +251,25 @@ trait RDBMExtractor {
     splitPointsToPredicates(splitPoints, tableMetadata)
   }
 
-  private[rdbm] def splitPointCol(tableMetadata: TableExtractionMetadata) =
-    if (tableMetadata.primaryKeys.tail.nonEmpty) s"CONCAT(${tableMetadata.primaryKeys.map(escapeKeyword).mkString(",'-',")})"
-    else escapeKeyword(tableMetadata.primaryKeys.head)
+  private[rdbm] def splitPointCol(tableMetadata: ExtractionMetadata) =
+    logAndReturn((if (tableMetadata.pks.tail.nonEmpty) s"CONCAT(${tableMetadata.pks.map(escapeKeyword).mkString(",'-',")})"
+    else escapeKeyword(tableMetadata.pks.head)),
+      (col: String) => s"Split point col: $col",
+      Level.Info)
 
   //TODO: Need to look into ordering of primary keys as clustered index could have different ordering
-  private[rdbm] def splitPointsQuery(tableMetadata: TableExtractionMetadata
+  private[rdbm] def splitPointsQuery(tableMetadata: ExtractionMetadata
                                      , lastUpdated: Option[Timestamp]
                                      , maxRowsPerPartition: Int): String = {
     s"""(
        |select split_point from (
-       |select ${splitPointCol(tableMetadata)} as split_point, row_number() over (order by ${tableMetadata.primaryKeys.map(escapeKeyword).mkString(",")}) as _row_num
+       |select ${splitPointCol(tableMetadata)} as split_point, row_number() over (order by ${tableMetadata.pks.map(escapeKeyword).mkString(",")}) as _row_num
        |${fromQueryPart(tableMetadata, lastUpdated)}
        |) ids where _row_num % $maxRowsPerPartition = 0) s""".stripMargin
   }
 
   //TODO: For composite keys, we can use first pk col in where clause as well as the concat to avoid full scans
-  private[rdbm] def splitPointsToPredicates(splitPoints: Seq[String], tableMetadata: TableExtractionMetadata): Option[Array[String]] = {
+  private[rdbm] def splitPointsToPredicates(splitPoints: Seq[String], tableMetadata: ExtractionMetadata): Option[Array[String]] = {
     val splitPointColumn = splitPointCol(tableMetadata)
     if (splitPoints.nonEmpty) {
       val mainPredicates = if (splitPoints.tail.nonEmpty) {
@@ -278,17 +285,6 @@ trait RDBMExtractor {
     else None
   }
 
-}
-
-case class TableExtractionMetadata(schemaName: String
-                                   , tableName: String
-                                   , primaryKeys: Seq[String]
-                                   , lastUpdatedColumn: Option[String] = None) {
-
-  def qualifiedTableName(escapeKeyword: String => String): String =
-    s"${escapeKeyword(schemaName)}.${escapeKeyword(tableName)}"
-
-  def labelName: String = s"${schemaName}_$tableName"
 }
 
 case class IncorrectUserPKException(userPKs: Seq[String], dbPKs: Seq[String]) extends Exception(

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
@@ -142,7 +142,7 @@ trait RDBMExtractor extends Logging {
     *                            of jdbc connections to open by limiting the number of executors for your application.
     * @return (Dataset for the given table, Column to use as the last updated)
     */
-  protected def loadDataset[A <: ExtractionMetadata](meta: Map[String, String]
+  protected def loadDataset(meta: Map[String, String]
                             , lastUpdated: Option[Timestamp]
                             , maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
     val tableMetadata = CaseClassConfigParser.fromMap[TableExtractionMetadata](meta)

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
@@ -81,11 +81,11 @@ class SQLServerExtractor(override val sparkSession: SparkSession
     ((primaryKeys, getTablePKs(dbSchemaName, transformTableNameForRead(tableName))) match {
       case (Some(userPKs), Some(pksFromDB)) if userPKs.sorted != pksFromDB.sorted =>
         Failure(IncorrectUserPKException(userPKs, pksFromDB))
-      case (Some(userPKs), None) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
-      case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
+      case (Some(userPKs), None) => Success(TableExtractionMetadata.fromPkSeq(dbSchemaName, tableName, userPKs, lastUpdatedColumn))
+      case (_, Some(pksFromDB)) => Success(TableExtractionMetadata.fromPkSeq(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
     }).map(meta => AuditTableInfo(meta.tableName
-      , meta.pks
+      , meta.pkCols
       , RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString)
       , retainStorageHistory(meta.lastUpdatedColumn)
     ))

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
@@ -85,7 +85,7 @@ class SQLServerExtractor(override val sparkSession: SparkSession
       case (_, Some(pksFromDB)) => Success(TableExtractionMetadata(dbSchemaName, tableName, pksFromDB, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
     }).map(meta => AuditTableInfo(meta.tableName
-      , meta.primaryKeys
+      , meta.pks
       , RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString)
       , retainStorageHistory(meta.lastUpdatedColumn)
     ))

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
@@ -88,7 +88,7 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
       })
   }
 
-  override def loadDataset(meta: Map[String, String]
+  override def loadDataset[A <: ExtractionMetadata](meta: Map[String, String]
                            , lastUpdated: Option[Timestamp]
                            , maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
     val sqlServerTableMetadata: SQLServerTemporalTableMetadata = CaseClassConfigParser.fromMap[SQLServerTemporalTableMetadata](meta)

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
@@ -125,8 +125,8 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
     (tableMetadata.lastUpdatedColumn, tableMetadata.historyTableName, tableMetadata.startColName, tableMetadata.endColName, lastUpdated) match {
       case (Some(lastUpdatedCol), Some(_), Some(startCol), Some(endCol), Some(ts)) =>
         s"""from ${tableMetadata.qualifiedTableName(escapeKeyword)}
-           |for SYSTEM_TIME from '$ts' to '9999-12-31'
-           |where ${escapeKeyword(endCol)} < '9999-12-31 23:59:59' or ${escapeKeyword(startCol)} >= '$ts'""".stripMargin
+           |for SYSTEM_TIME from '$ts' to '$upperDateBound'
+           |where ${escapeKeyword(endCol)} < '$upperDateTimeBound' or ${escapeKeyword(startCol)} >= '$ts'""".stripMargin
       // All we care about here is that we are in a history table, this is the case where we want all the history unified
       case (Some(_), Some(_), Some(_), Some(_), None) =>
         s"""from ${tableMetadata.qualifiedTableName(escapeKeyword)}
@@ -146,7 +146,7 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
   private def sourceType(endColName: String): String = {
     s"""source_type =
        |  case
-       |    when $endColName = '$upperDateTimeBound' then 0
+       |    when ${escapeKeyword(endColName)} = '$upperDateTimeBound' then 0
        |    else 1
        |  end
        |""".stripMargin

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
@@ -12,16 +12,27 @@ import scala.util.{Failure, Success, Try}
 
 
 /**
-  * A mechanism for generating Waimak actions to extract data from a SQL Server instance containing temporal tables
-  * Tables can be a mixture of temporal and non-temporal - both will be handled appropriately
-  *
-  * @param sparkSession              the SparkSession
-  * @param extraConnectionProperties jdbc properties to use (In addition to username and password)
-  */
+ * A mechanism for generating Waimak actions to extract data from a SQL Server instance containing temporal tables
+ * Tables can be a mixture of temporal and non-temporal - both will be handled appropriately
+ *
+ * @param sparkSession              the SparkSession
+ * @param extraConnectionProperties jdbc properties to use (In addition to username and password)
+ */
 class SQLServerTemporalExtractor(override val sparkSession: SparkSession
                                  , sqlServerConnectionDetails: SQLServerConnectionDetails
                                  , extraConnectionProperties: Properties = new Properties()) extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties) with Logging {
 
+  lazy val allTableMetadata: Map[String, SQLServerTemporalTableMetadata] = {
+    import sparkSession.implicits._
+    RDBMIngestionUtils.lowerCaseAll(
+      sparkSession.read
+        .option("driver", driverClass)
+        .jdbc(connectionDetails.jdbcString, metadataQuery, connectionProperties)
+    )
+      .as[SQLServerTemporalTableMetadata]
+      .collect()
+      .map(metadata => s"${metadata.schemaName}.${metadata.tableName}" -> metadata).toMap
+  }
   val metadataQuery: String =
     s"""(
        | SELECT SCHEMA_NAME(main.schema_id) as schemaName,
@@ -55,18 +66,6 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
        |  main.temporal_type
   ) m""".stripMargin
 
-  lazy val allTableMetadata: Map[String, SQLServerTemporalTableMetadata] = {
-    import sparkSession.implicits._
-    RDBMIngestionUtils.lowerCaseAll(
-      sparkSession.read
-        .option("driver", driverClass)
-        .jdbc(connectionDetails.jdbcString, metadataQuery, connectionProperties)
-    )
-      .as[SQLServerTemporalTableMetadata]
-      .collect()
-      .map(metadata => s"${metadata.schemaName}.${metadata.tableName}" -> metadata).toMap
-  }
-
   override def getTableMetadata(dbSchemaName: String
                                 , tableName: String
                                 , primaryKeys: Option[Seq[String]]
@@ -92,11 +91,13 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
                            , lastUpdated: Option[Timestamp]
                            , maxRowsPerPartition: Option[Int]): (Dataset[_], Column) = {
     val sqlServerTableMetadata: SQLServerTemporalTableMetadata = CaseClassConfigParser.fromMap[SQLServerTemporalTableMetadata](meta)
+
     val explicitColumnSelects = (for {
       startCol <- sqlServerTableMetadata.startColName
       endCol <- sqlServerTableMetadata.endColName
     } yield Seq(startCol, endCol).map(col => s"CAST($col AS DATETIME2(7)) AS $col"))
       .foldRight(Seq("0 as source_type"))((cols, dateCols) => cols ++ dateCols)
+
     val mainTable = sparkLoad(sqlServerTableMetadata.mainTableMetadata, lastUpdated, maxRowsPerPartition, explicitColumnSelects)
       .toDF
     val fullTable = sqlServerTableMetadata.historyTableMetadata.foldLeft(mainTable)((df, historyMetadata) => {
@@ -108,25 +109,9 @@ class SQLServerTemporalExtractor(override val sparkSession: SparkSession
     (fullTable, resolveLastUpdatedColumn(sqlServerTableMetadata.mainTableMetadata, sparkSession))
   }
 
-}
+  override def fromQueryPart(tableMetadata: ExtractionMetadata, lastUpdated: Option[Timestamp]): String = {
+    logInfo(s"table meta: ${tableMetadata} lastUpdated: ${lastUpdated}")
+    super.fromQueryPart(tableMetadata, lastUpdated)
+  }
 
-
-case class SQLServerTemporalTableMetadata(schemaName: String
-                                          , tableName: String
-                                          , historyTableSchema: Option[String] = None
-                                          , historyTableName: Option[String] = None
-                                          , startColName: Option[String] = None
-                                          , endColName: Option[String] = None
-                                          , primaryKeys: String) {
-
-  def pkCols: Seq[String] = primaryKeys.split(";").toSeq
-
-  def mainTableMetadata: TableExtractionMetadata = TableExtractionMetadata(schemaName, tableName, pkCols, startColName)
-
-  def historyTableMetadata: Option[TableExtractionMetadata] = for {
-    schema <- historyTableSchema
-    table <- historyTableName
-  } yield TableExtractionMetadata(schema, table, pkCols, endColName)
-
-  def isTemporal: Boolean = historyTableMetadata.isDefined
 }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
@@ -25,10 +25,10 @@ class SQLServerViewExtractor(override val sparkSession: SparkSession
                                 , lastUpdatedColumn: Option[String]
                                 , retainStorageHistory: Option[String] => Boolean): Try[AuditTableInfo] = {
     (primaryKeys match {
-      case Some(userPKS) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKS, lastUpdatedColumn))
+      case Some(userPKS) => Success(TableExtractionMetadata.fromPkSeq(dbSchemaName, tableName, userPKS, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
     }).map(meta => {
-      AuditTableInfo(meta.tableName, meta.pks, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn))
+      AuditTableInfo(meta.tableName, meta.pkCols, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn))
     })
   }
 }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
@@ -28,7 +28,7 @@ class SQLServerViewExtractor(override val sparkSession: SparkSession
       case Some(userPKS) => Success(TableExtractionMetadata(dbSchemaName, tableName, userPKS, lastUpdatedColumn))
       case _ => Failure(PKsNotFoundOrProvidedException)
     }).map(meta => {
-      AuditTableInfo(meta.tableName, meta.primaryKeys, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn))
+      AuditTableInfo(meta.tableName, meta.pks, RDBMIngestionUtils.caseClassToMap(meta).mapValues(_.toString), retainStorageHistory(meta.lastUpdatedColumn))
     })
   }
 }

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
@@ -26,6 +26,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
   val insertDateTime: ZonedDateTime = insertTimestamp.toLocalDateTime.atZone(ZoneOffset.UTC)
 
   override def beforeAll(): Unit = {
+    cleanupTables() // Just for now
     setupTables()
   }
 
@@ -78,7 +79,11 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
 
   def cleanupTables(): Unit = {
     executeSQl(Seq(
-      "alter table TestTemporal set (SYSTEM_VERSIONING = OFF)"
+      """if exists (SELECT * FROM INFORMATION_SCHEMA.TABLES
+        |           WHERE TABLE_NAME = N'TestTemporal')
+        |begin
+        |    alter table TestTemporal set (SYSTEM_VERSIONING = OFF)
+        |end""".stripMargin
       , "drop table if exists TestTemporal"
       , "drop table if exists TestTemporalHistory"
       , "drop table if exists TestNonTemporal"

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
@@ -172,7 +172,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
 
       val res1 = executor.execute(writeFlow)
       res1._2.inputs.get[Dataset[_]]("testtemporal").sort("source_type", "testtemporalid")
-        .as[TestTemporal].collect() should be(Seq(
+        .as[TestTemporal].collect() should contain theSameElementsAs (Seq(
         TestTemporal(1, "New Value 1", 0)
         , TestTemporal(2, "Value2", 0)
         , TestTemporal(3, "Value3", 0)
@@ -184,7 +184,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
       ))
 
       res1._2.inputs.get[Dataset[_]]("testnontemporal").sort("testnontemporalid1", "testnontemporalid2")
-        .as[TestNonTemporal].collect() should be(Seq(
+        .as[TestNonTemporal].collect() should contain theSameElementsAs (Seq(
         TestNonTemporal(1, 1, "V1")
         , TestNonTemporal(2, 1, "V2")
         , TestNonTemporal(2, 2, "V3")
@@ -195,7 +195,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
       val readFlow = flow.loadFromStorage(s"$testingBaseDir/output")("testtemporal")
       val res2 = executor.execute(readFlow)
       res2._2.inputs.get[Dataset[_]]("testtemporal").sort("source_type", "testtemporalid")
-        .as[TestTemporal].collect() should be(Seq(
+        .as[TestTemporal].collect() should contain theSameElementsAs (Seq(
         TestTemporal(1, "New Value 1", 0)
         , TestTemporal(2, "Value2", 0)
         , TestTemporal(3, "Value3", 0)
@@ -302,7 +302,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
     val res = executor.execute(deltaWriteFlow)
 
     val testTemporal = res._2.inputs.get[Dataset[_]]("testtemporal")
-
+    testTemporal.sort("TestTemporalID").show()
     testTemporal.sort("source_type", "testtemporalid")
       .as[TestTemporal].collect()
       //For some reason, sometimes (not consistently) > seems to act like >= on these datetime2 fields so we need to filter

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestSQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestSQLServerViewExtractor.scala
@@ -21,7 +21,7 @@ class TestSQLServerViewExtractor extends SparkSpec {
         , None) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
         "schemaName" -> "testSchema"
         , "tableName" -> "testTable"
-        , "pks" -> "key1,key2"
+        , "primaryKeys" -> "key1,key2"
         , "lastUpdatedColumn" -> "lastUpdated")
         , true
       )))
@@ -36,7 +36,7 @@ class TestSQLServerViewExtractor extends SparkSpec {
         , Some(false)) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
         "schemaName" -> "testSchema"
         , "tableName" -> "testTable"
-        , "pks" -> "key1,key2"
+        , "primaryKeys" -> "key1,key2"
         , "lastUpdatedColumn" -> "lastUpdated")
         , false
       )))
@@ -48,7 +48,7 @@ class TestSQLServerViewExtractor extends SparkSpec {
         , Some(true)) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
         "schemaName" -> "testSchema"
         , "tableName" -> "testTable"
-        , "pks" -> "key1,key2")
+        , "primaryKeys" -> "key1,key2")
         , true
       )))
     }

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestSQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/TestSQLServerViewExtractor.scala
@@ -21,7 +21,7 @@ class TestSQLServerViewExtractor extends SparkSpec {
         , None) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
         "schemaName" -> "testSchema"
         , "tableName" -> "testTable"
-        , "primaryKeys" -> "key1,key2"
+        , "pks" -> "key1,key2"
         , "lastUpdatedColumn" -> "lastUpdated")
         , true
       )))
@@ -36,7 +36,7 @@ class TestSQLServerViewExtractor extends SparkSpec {
         , Some(false)) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
         "schemaName" -> "testSchema"
         , "tableName" -> "testTable"
-        , "primaryKeys" -> "key1,key2"
+        , "pks" -> "key1,key2"
         , "lastUpdatedColumn" -> "lastUpdated")
         , false
       )))
@@ -48,7 +48,7 @@ class TestSQLServerViewExtractor extends SparkSpec {
         , Some(true)) should be(Success(AuditTableInfo("testTable", Seq("key1", "key2"), Map(
         "schemaName" -> "testSchema"
         , "tableName" -> "testTable"
-        , "primaryKeys" -> "key1,key2")
+        , "pks" -> "key1,key2")
         , true
       )))
     }


### PR DESCRIPTION
# Description

When extracting from historic tables in sql server we previously would perform two select statements. The first select would pull from the table, and include rows at the current time, and the second would pull all changes from the historic table. These would then be unioned together in the spark code.

We (in cox automotive) have seen issues where this historic extraction wasn't working correctly: rows would be in the wrong state when we queried in this way. We believe this is related to the two queries being non-transactional: since they are executed outside of a transaction the underlying rows might have changed before we query for the history. This change makes the extraction happen inside of a single sql query, which should provide the transactional isolation we need.

## Type of change

Bug fix (non-breaking change which fixes an issue)
