### PR TITLE
Fix WriteAsNamedFilesAction to work with text format correctly

### DIFF
--- a/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/WriteAsNamedFilesAction.scala
+++ b/waimak-core/src/main/scala/com/coxautodata/waimak/dataflow/spark/WriteAsNamedFilesAction.scala
@@ -27,10 +27,11 @@ case class WriteAsNamedFilesAction(label: String, tempBasePath: Path, destBasePa
 
   override def performAction(inputs: DataFlowEntities, flowContext: SparkFlowContext): Try[ActionResult] = Try {
 
+    checkTextWriteOptions(numberOfFiles, format)
     val tempPath = new Path(tempBasePath, UUID.randomUUID().toString)
     inputs.get[Dataset[_]](label).repartition(numberOfFiles).write.options(options).format(format).save(tempPath.toString)
 
-    val foundFiles = flowContext.fileSystem.globStatus(new Path(tempPath, s"part-*.*$format*"))
+    val foundFiles = flowContext.fileSystem.globStatus(new Path(tempPath, s"part-*.*${fixTextExtension(format)}*"))
     if (numberOfFiles != foundFiles.length) throw new DataFlowException(s"Number of files found [${foundFiles.length}] did not match requested number of files [$numberOfFiles]")
     foundFiles
       .zip {
@@ -51,5 +52,16 @@ case class WriteAsNamedFilesAction(label: String, tempBasePath: Path, destBasePa
 }
 
 object WriteAsNamedFilesAction {
+  def checkTextWriteOptions(numberOfFiles: Int, format: String): Unit = {
+    if (format == "text") {
+      if (numberOfFiles > 1) throw new IllegalArgumentException("When writing text files only 1 file is able to be written")
+    }
+  }
+
+  def fixTextExtension(ext: String): String = ext match {
+    case "text" => "txt"
+    case _ @ a => a
+  }
+
   def getOutputExtension(path: Path): String = path.getName.dropWhile(_ != '.')
 }


### PR DESCRIPTION
Fix WriteAsNamedFilesAction to correctly find the written file when using the text format, and only allow one file to be written as text (mirroring spark).

# Description

When writing text format we do not find the written files, as we assume that the format option ("text") is equal to the file extension ("txt"). This change checks the format and correctly finds txt files when asking for the text format. Also, the spark file writer cannot deal with writing more than 1 file, so we throw if requesting more than 1 file to be written.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests to check this functionality.
