### PR TITLE
Optimise sql server query to detect highest timestamp for table correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <java.sdk.version>1.8</java.sdk.version>
         <scalatest.version>3.0.8</scalatest.version>
         <azure.storage.version>6.1.0</azure.storage.version>
-        <jdbc.mssql.version>6.1.0.jre8</jdbc.mssql.version>
+        <jdbc.mssql.version>8.4.1.jre8</jdbc.mssql.version>
         <jdbc.postgres.version>42.2.2</jdbc.postgres.version>
         <docker.maven.plugin.version>0.25.2</docker.maven.plugin.version>
         <scala.maven.plugin.version>3.2.2</scala.maven.plugin.version>

--- a/waimak-rdbm-ingestion/pom.xml
+++ b/waimak-rdbm-ingestion/pom.xml
@@ -71,7 +71,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>microsoft/mssql-server-linux:2017-latest</name>
+                            <name>mcr.microsoft.com/mssql/server:2019-latest</name>
                             <alias>it-sqlserver</alias>
                             <run>
                                 <namingStrategy>alias</namingStrategy>

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerBaseExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerBaseExtractor.scala
@@ -13,7 +13,9 @@ abstract class SQLServerBaseExtractor(override val connectionDetails: SQLServerC
 
   override val sourceDBSystemTimestampFunction = "CURRENT_TIMESTAMP"
 
-  override def escapeKeyword(keyword: String) = s"[$keyword]"
+  override def escapeKeyword(keyword: String) = if (escapeGuard(keyword)) s"[$keyword]" else keyword
+
+  private def escapeGuard(keyword: String): Boolean = !(keyword.contains("[") && keyword.contains("]"))
 }
 
 /**

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractorIntegrationTest.scala
@@ -9,7 +9,6 @@ import com.coxautodata.waimak.rdbm.ingestion.RDBMIngestionActions._
 import com.coxautodata.waimak.storage.AuditTableInfo
 import com.coxautodata.waimak.storage.StorageActions._
 import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.functions.max
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.util.Success
@@ -127,6 +126,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
           , "historyTableSchema" -> "dbo"
           , "historyTableName" -> "testtemporalhistory"
           , "startColName" -> "sysstarttime"
+          , "databaseUpperTimestamp" -> "9999-12-31 23:59:59.0000000"
           , "endColName" -> "sysendtime")
           , true))
       )
@@ -143,7 +143,8 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
         Success(AuditTableInfo("testnontemporal", Seq("testnontemporalid1", "testnontemporalid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testnontemporal"
-          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2")
+          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2"
+          , "databaseUpperTimestamp" -> "9999-12-31 23:59:59.0000000")
           , false))
       )
     }
@@ -154,7 +155,8 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
         Success(AuditTableInfo("testnontemporal", Seq("testnontemporalid1", "testnontemporalid2"), Map(
           "schemaName" -> "dbo"
           , "tableName" -> "testnontemporal"
-          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2")
+          , "primaryKeys" -> "testnontemporalid1;testnontemporalid2"
+          , "databaseUpperTimestamp" -> "9999-12-31 23:59:59.0000000")
           , true))
       )
 
@@ -166,6 +168,7 @@ class SQLServerTemporalExtractorIntegrationTest extends SparkAndTmpDirSpec with 
           , "historyTableSchema" -> "dbo"
           , "historyTableName" -> "testtemporalhistory"
           , "startColName" -> "sysstarttime"
+          , "databaseUpperTimestamp" -> "9999-12-31 23:59:59.0000000"
           , "endColName" -> "sysendtime")
           , false))
       )


### PR DESCRIPTION
# Description

Change the sql server temporal extractor to select the upper bound timestamp bound from the table, fixing problems where the upper bound would be '9999-12-31 23:59:59.0000000' rather than '9999-12-31 23:59:59.9999999' when casting Datetime2(0) to Datetime2(7). 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested against the existing database tests and manually by running sql against the db here at cox auto.
