### PR TITLE
Fix the SQL Server Temporal Extractor when extracting from an empty table

### DIFF
--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/ExtractionMetadata.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/ExtractionMetadata.scala
@@ -69,7 +69,7 @@ case class SQLServerTemporalTableMetadata(schemaName: String
                                           , override val startColName: Option[String] = None
                                           , override val endColName: Option[String] = None
                                           , primaryKeys: String
-                                          , override val databaseUpperTimestamp: Option[String] = Some("9999-12-31 23:59:59.0000000")) extends ExtractionMetadata {
+                                          , override val databaseUpperTimestamp: Option[String] = Some("9999-12-31 23:59:59")) extends ExtractionMetadata {
 
   def mainTableMetadata: TableExtractionMetadata = TableExtractionMetadata.fromPkSeq(schemaName, tableName, pkCols, startColName)
 


### PR DESCRIPTION
# Description

After the previous changes we select the max ts from a history table to determine what the max timestamp should be. However, when the table is empty this query returns null, which causes repeated extractions to fail. This change instead has the value default to the set max timestamp, instead of returning null in this case.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new test and tested manually against both the running test db and a db here at cox auto.
