### PR TITLE
Enable spark 3.1 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ cache:
 matrix:
   include:
     - env: MAVEN_PROFILE="apache-2.4.7_2.11" SCALA_VERSION="2.11" EXTRA_MAVEN_OPTIONS='-pl !waimak-deequ'
+    - env: MAVEN_PROFILE="apache-3.1.1_2.12" SCALA_VERSION="2.12"
     - env: MAVEN_PROFILE="apache-2.4.5_2.11" DEPLOY_PROFILE="true" COVERAGE_PROFILE="true" SCALA_VERSION="2.11" EXTRA_MAVEN_OPTIONS='-pl !waimak-deequ'
-    - env: MAVEN_PROFILE="apache-3.0.1_2.12" DEPLOY_PROFILE="true" SCALA_VERSION="2.12"
+    - env: MAVEN_PROFILE="apache-3.0.1_2.12" DEPLOY_PROFILE="true" COVERAGE_PROFILE="true" SCALA_VERSION="2.12"
 
 before_install:
   - bash dev/change-scala-version.sh "$SCALA_VERSION"

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/SparkSpec.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/SparkSpec.scala
@@ -10,8 +10,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 /**
-  * Created by Vicky Avison on 24/10/17.
-  */
+ * Created by Vicky Avison on 24/10/17.
+ */
 trait SparkSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
 
   var sparkSession: SparkSession = _
@@ -19,12 +19,16 @@ trait SparkSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
   val appName: String
 
   /**
+   * In spark 3  */
+  def parquetLegacyModeForSpark2To3(enabled: Boolean = false): String =
+    if (enabled) "LEGACY" else "CORRECTED"
+
+  /**
    * Allows configuring spark session options. Override this in your own tests to set any
    * config options you might wish to add. This default implementation also detects if you are
    * running the tests on windows, and sets the bindAddress option to make the tests work.
    *
    * @see com.coxautodata.waimak.metastore.TestHiveDBConnector for an example
-   *
    * @return a spark session
    */
   def builderOptions: SparkSession.Builder => SparkSession.Builder = { sparkSession =>
@@ -41,10 +45,31 @@ trait SparkSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
       .config("spark.ui.enabled", "false")
 
     sparkSession = builderOptions(preBuilder).getOrCreate()
+
+    getSparkVersion(sparkSession) match {
+      case SparkVersion(2, _, _) => ()
+      case SparkVersion(3, _, _) => configureParquetReaderWriterOptionsForSpark3(sparkSession)
+      case _ => ()
+    }
   }
 
   override def afterEach(): Unit = {
     sparkSession.stop()
+  }
+
+  def getSparkVersion(spark: SparkSession): SparkVersion =
+    spark.version.split(".").toList.map(_.toInt) match {
+      case maj :: min :: p :: Nil => SparkVersion(maj, min, Some(p))
+      case maj :: min :: Nil => SparkVersion(maj, min, None)
+      case _@v => throw new IllegalStateException(s"The spark version of ${v.mkString} cannot be parsed")
+    }
+
+  def configureParquetReaderWriterOptionsForSpark3(sparkSession: SparkSession): Unit = {
+    val setting = parquetLegacyModeForSpark2To3()
+    sparkSession.conf.set("spark.sql.legacy.parquet.int96RebaseModeInWrite", setting)
+    sparkSession.conf.set("spark.sql.legacy.parquet.int96RebaseModeInRead", setting)
+    sparkSession.conf.set("spark.sql.legacy.parquet.datetimeRebaseModeInWrite", setting)
+    sparkSession.conf.set("spark.sql.legacy.parquet.datetimeRebaseModeInRead", setting)
   }
 }
 
@@ -68,3 +93,4 @@ trait SparkAndTmpDirSpec extends SparkSpec {
   }
 }
 
+case class SparkVersion(major: Int, minor: Int, point: Option[Int])

--- a/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
+++ b/waimak-core/src/test/scala/com/coxautodata/waimak/dataflow/spark/TestSparkDataFlow.scala
@@ -454,7 +454,9 @@ class TestSparkDataFlow extends SparkAndTmpDirSpec {
         executor.execute(flow)
       }
       e.getMessage should be(s"Exception performing action: ${flow.actions.drop(4).head.guid}: Action: write Inputs: [person] Outputs: []")
-      e.cause.getMessage should be("Table `default`.`person` already exists.;")
+      // In spark 3.1 the trailing ';' seems to have been removed, however everything else seems to be the same
+      // In order to make these tests work between spark versions we remove the ';' from the message
+      e.cause.getMessage.replace(";", "") should be("Table `default`.`person` already exists.")
 
       val secondFlow = SparkDataFlow.empty(sparkSession, tmpDir)
         .openCSV(basePath)("csv_1", "csv_2")


### PR DESCRIPTION
Fixes a single test which fails on spark 3.1, otherwise it all worked perfectly!