### PR TITLE
Empty mssql bug

### DIFF
--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/RDBMExtractor.scala
@@ -60,6 +60,8 @@ trait RDBMExtractor extends Logging {
     */
   def transformTableNameForRead: String => String = identity
 
+  def constrainLastUpdatedTimestampRange(timestamp: Timestamp, label: String, meta: Map[String, String]): Timestamp = timestamp
+
   /**
     * Tries to get whatever metadata information it can from the database
     * Uses the optional provided values for pks and lastUpdated if it cannot get them from the database.

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerBaseExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerBaseExtractor.scala
@@ -1,5 +1,8 @@
 package com.coxautodata.waimak.rdbm.ingestion
 
+import com.coxautodata.waimak.configuration.CaseClassConfigParser
+
+import java.sql.Timestamp
 import java.util.Properties
 
 /**
@@ -7,13 +10,53 @@ import java.util.Properties
   *
   */
 abstract class SQLServerBaseExtractor(override val connectionDetails: SQLServerConnectionDetails,
-                                      override val extraConnectionProperties: Properties) extends RDBMExtractor {
+                                      override val extraConnectionProperties: Properties,
+                                      val checkLastUpdatedTimestampRange: Boolean = false) extends RDBMExtractor {
 
   override val driverClass = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
 
   override val sourceDBSystemTimestampFunction = "CURRENT_TIMESTAMP"
 
+  val datetimeLowerTimestamp = Timestamp.valueOf("1900-01-01 00:00:00.0")
+
+  def timestampDataTypeQuery(tableName: String, columnName: String): String =
+    s"(select DATA_TYPE from INFORMATION_SCHEMA.COLUMNS where TABLE_NAME = '${tableName}' and COLUMN_NAME = '${columnName}') m"
+
+  def inferTimestampColDataType(label: String, lastUpdated: String) = {
+    val columnType = RDBMIngestionUtils.lowerCaseAll(
+      sparkSession.read
+        .option("driver", driverClass)
+        .jdbc(connectionDetails.jdbcString, timestampDataTypeQuery(label, lastUpdated), connectionProperties)
+    )
+
+    import columnType.sparkSession.implicits._
+
+    columnType.select("data_type").as[String].first()
+  }
+
   override def escapeKeyword(keyword: String) = if (escapeGuard(keyword)) s"[$keyword]" else keyword
+
+  override def constrainLastUpdatedTimestampRange(timestamp: Timestamp, label: String, meta: Map[String, String]): Timestamp = {
+    val tableMetadata = CaseClassConfigParser.fromMap[TableExtractionMetadata](meta)
+
+    (checkLastUpdatedTimestampRange, tableMetadata.lastUpdatedColumn) match {
+      case (true, Some(ts)) => mapLastUpdatedIntoAvailableRange(timestamp, label, ts)
+      case _ => timestamp
+    }
+  }
+
+  private def mapLastUpdatedIntoAvailableRange(timestamp: Timestamp, label: String, lastUpdated: String): Timestamp = {
+    inferTimestampColDataType(label, lastUpdated) match {
+      case "datetime" => if (timestamp.before(datetimeLowerTimestamp)) {
+        logWarning(s"Timestamp out of range for datetime column $lastUpdated detected, using $datetimeLowerTimestamp instead")
+        datetimeLowerTimestamp
+      } else timestamp
+      case "datetime2" => timestamp
+      case _ @ colType =>
+        logWarning(s"Last updated timestamp in the database has type $colType for table $label which may be incorrect")
+        timestamp
+    }
+  }
 
   private def escapeGuard(keyword: String): Boolean = !(keyword.contains("[") && keyword.contains("]"))
 }

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractor.scala
@@ -23,7 +23,9 @@ import scala.util.{Failure, Success, Try}
 class SQLServerExtractor(override val sparkSession: SparkSession
                          , sqlServerConnectionDetails: SQLServerConnectionDetails
                          , extraConnectionProperties: Properties = new Properties()
-                         , override val transformTableNameForRead: String => String = identity) extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties) with Logging {
+                         , override val transformTableNameForRead: String => String = identity
+                         , override val checkLastUpdatedTimestampRange: Boolean = false)
+  extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties, checkLastUpdatedTimestampRange) with Logging {
 
 
   val pkQuery: String =

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerTemporalExtractor.scala
@@ -21,7 +21,9 @@ import scala.util.{Failure, Success, Try}
  */
 class SQLServerTemporalExtractor(override val sparkSession: SparkSession
                                  , sqlServerConnectionDetails: SQLServerConnectionDetails
-                                 , extraConnectionProperties: Properties = new Properties()) extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties) with Logging {
+                                 , extraConnectionProperties: Properties = new Properties()
+                                 , override val checkLastUpdatedTimestampRange: Boolean = false)
+  extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties, checkLastUpdatedTimestampRange) with Logging {
 
   lazy val allTableMetadata: Map[String, SQLServerTemporalTableMetadata] = {
     import sparkSession.implicits._

--- a/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
+++ b/waimak-rdbm-ingestion/src/main/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerViewExtractor.scala
@@ -17,7 +17,9 @@ import scala.util.{Failure, Success, Try}
 class SQLServerViewExtractor(override val sparkSession: SparkSession
                              , sqlServerConnectionDetails: SQLServerConnectionDetails
                              , extraConnectionProperties: Properties = new Properties()
-                             , override val transformTableNameForRead: String => String = identity) extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties) {
+                             , override val transformTableNameForRead: String => String = identity
+                             , override val checkLastUpdatedTimestampRange: Boolean = false)
+  extends SQLServerBaseExtractor(sqlServerConnectionDetails, extraConnectionProperties, checkLastUpdatedTimestampRange) {
 
   override def getTableMetadata(dbSchemaName: String
                                 , tableName: String

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractorIntegrationTest.scala
@@ -258,6 +258,8 @@ class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAn
         TestTableDatatime(2, 3, "v2")
       )
 
+      executor.execute(writeFlow)
+
       // Clear the tables for any other testing
 
       cleanupTables()

--- a/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractorIntegrationTest.scala
+++ b/waimak-rdbm-ingestion/src/test/scala/com/coxautodata/waimak/rdbm/ingestion/SQLServerExtractorIntegrationTest.scala
@@ -4,6 +4,7 @@ import java.sql.{DriverManager, Timestamp}
 import java.time.{ZoneOffset, ZonedDateTime}
 import com.coxautodata.waimak.dataflow.{DataFlowException, Waimak}
 import com.coxautodata.waimak.dataflow.spark.SparkAndTmpDirSpec
+import com.coxautodata.waimak.log.Logging
 import com.coxautodata.waimak.rdbm.ingestion.RDBMIngestionActions._
 import com.coxautodata.waimak.storage.{AuditTableInfo, StorageException}
 import org.apache.spark.sql.Dataset
@@ -11,7 +12,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import scala.util.{Failure, Success}
 
-class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAndAfterAll {
+class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAndAfterAll with Logging {
 
   override val appName: String = "SQLServerConnectorIntegrationTest"
 
@@ -249,6 +250,8 @@ class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAn
 
       Thread.sleep(400)
 
+      logInfo("Extracting newly inserted rows")
+
       val output = executor.execute(writeFlow)
 
       output._2.inputs.get[Dataset[_]]("testtableemptydatetime")
@@ -257,6 +260,8 @@ class SQLServerExtractorIntegrationTest extends SparkAndTmpDirSpec with BeforeAn
         TestTableDatatime(1, 1, "v1"),
         TestTableDatatime(2, 3, "v2")
       )
+
+      logInfo("Running final extraction with no new rows")
 
       executor.execute(writeFlow)
 


### PR DESCRIPTION
# Description

Extracting from an empty table in sql server fails when the last updated column is set to a datetime (instead of the new datetime2 type). This is because the lower timestamp that is produced from the storage layer is out of the range of the datetime type. This change tries to detect that circumstance and map the timestamp into a low value that is inside the range.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
